### PR TITLE
Ignore generated gemfiles and unpacked gem contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@
 
 # rspec failure tracking
 .rspec_status
+
+# generate gem and unpacked gem contents
+*.gem
+laa-fee-calculator-client*/


### PR DESCRIPTION
Self-descriptive.

They shouldn't be tracked by git.
