### PR TITLE
Modify default host

### DIFF
--- a/lib/laa/fee_calculator/configuration.rb
+++ b/lib/laa/fee_calculator/configuration.rb
@@ -3,13 +3,13 @@
 module LAA
   module FeeCalculator
     class Configuration
-      DEV_LAA_FEE_CALCULATOR_API_V1 = 'https://laa-fee-calculator-dev.apps.non-production.k8s.integration.dsd.io/api/v1'
+      LAA_FEE_CALCULATOR_API_V1 = 'https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1'
       HEADERS = { 'Accept' => 'application/json', 'User-Agent' => USER_AGENT }.freeze
 
       attr_accessor :host, :headers
 
       def initialize
-        @host ||= host || DEV_LAA_FEE_CALCULATOR_API_V1
+        @host ||= host || LAA_FEE_CALCULATOR_API_V1
         @headers ||= headers || HEADERS
       end
     end

--- a/lib/laa/fee_calculator/version.rb
+++ b/lib/laa/fee_calculator/version.rb
@@ -2,7 +2,7 @@
 
 module LAA
   module FeeCalculator
-    VERSION = "0.1.2"
+    VERSION = "0.1.3"
     USER_AGENT = "laa-fee-calculator-client/#{VERSION}"
   end
 end

--- a/spec/laa/fee_calculator/configuration_spec.rb
+++ b/spec/laa/fee_calculator/configuration_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe LAA::FeeCalculator::Configuration do
   describe '#host' do
     subject(:config) { described_class.new.host }
 
-    it 'defaults to develpoment laa fee calculator api v1' do
-      is_expected.to eql described_class::DEV_LAA_FEE_CALCULATOR_API_V1
+    it 'defaults to production laa fee calculator api v1' do
+      is_expected.to eql described_class::LAA_FEE_CALCULATOR_API_V1
     end
   end
 

--- a/spec/laa/fee_calculator/integration/fee_types_spec.rb
+++ b/spec/laa/fee_calculator/integration/fee_types_spec.rb
@@ -76,11 +76,8 @@ RSpec.describe LAA::FeeCalculator, :vcr do
           end
 
           context 'when filter reduces list' do
-            specify 'by is_basic and scenario' do
-              expect(fee_scheme.fee_types(is_basic: false, scenario: 8).size).to eql 33
-
-              # same result because the business logic of the api does not seem to be very useful
-              expect(fee_scheme.fee_types(scenario: 8).size).to eql 33 # same result because the business logic of the api is not useful
+            specify 'by scenario' do
+              expect(fee_scheme.fee_types(scenario: 8).size).to be < 36
             end
           end
 

--- a/spec/laa/fee_calculator_spec.rb
+++ b/spec/laa/fee_calculator_spec.rb
@@ -65,13 +65,13 @@ RSpec.describe LAA::FeeCalculator do
     it 'resets the configured host' do
       expect(described_class.configuration.host).to eql host
       described_class.reset
-      expect(described_class.configuration.host).to eql described_class::Configuration::DEV_LAA_FEE_CALCULATOR_API_V1
+      expect(described_class.configuration.host).to eql described_class::Configuration::LAA_FEE_CALCULATOR_API_V1
     end
 
     it 'resets the connection host' do
       expect(described_class::Connection.instance.host).to eql host
       described_class.reset
-      expect(described_class::Connection.instance.host).to eql described_class::Configuration::DEV_LAA_FEE_CALCULATOR_API_V1
+      expect(described_class::Connection.instance.host).to eql described_class::Configuration::LAA_FEE_CALCULATOR_API_V1
     end
   end
 end

--- a/spec/vcr/advocate_types_spec.yml
+++ b/spec/vcr/advocate_types_spec.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/1/advocate-types/
+    uri: http://localhost:8000/api/v1/fee-schemes/1/
     body:
       encoding: US-ASCII
       string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - laa-fee-calculator-client/0.1.1
+      - laa-fee-calculator-client/0.1.2
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -19,7 +19,45 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 29 Jul 2018 13:26:55 GMT
+      - Thu, 23 Aug 2018 10:33:58 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.6.5
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
+        Fee Scheme 9"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 10:33:58 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/1/advocate-types/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.1.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Aug 2018 10:33:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -38,7 +76,7 @@ http_interactions:
         alone"},{"id":"LEADJR","name":"Leading junior"},{"id":"LEDJR","name":"Led
         junior"},{"id":"QC","name":"QC"}]}'
     http_version: 
-  recorded_at: Sun, 29 Jul 2018 13:26:55 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:58 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/advocate-types/JRALONE/
@@ -49,7 +87,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - laa-fee-calculator-client/0.1.1
+      - laa-fee-calculator-client/0.1.2
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -58,7 +96,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 29 Jul 2018 13:26:55 GMT
+      - Thu, 23 Aug 2018 10:33:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -75,45 +113,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"id":"JRALONE","name":"Junior alone"}'
     http_version: 
-  recorded_at: Sun, 29 Jul 2018 13:26:55 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/1/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/0.1.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Sun, 29 Jul 2018 13:26:55 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.6.5
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '106'
-    body:
-      encoding: UTF-8
-      string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
-        Fee Scheme 9"}'
-    http_version: 
-  recorded_at: Sun, 29 Jul 2018 13:26:55 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:58 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/advocate-types/INVALID/
@@ -124,7 +124,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - laa-fee-calculator-client/0.1.1
+      - laa-fee-calculator-client/0.1.2
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -133,7 +133,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Sun, 29 Jul 2018 13:26:55 GMT
+      - Thu, 23 Aug 2018 10:33:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -150,7 +150,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
     http_version: 
-  recorded_at: Sun, 29 Jul 2018 13:26:55 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:58 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/2/
@@ -161,7 +161,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - laa-fee-calculator-client/0.1.1
+      - laa-fee-calculator-client/0.1.2
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -170,7 +170,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 29 Jul 2018 13:26:55 GMT
+      - Thu, 23 Aug 2018 10:33:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -188,7 +188,7 @@ http_interactions:
       string: '{"id":2,"start_date":"2016-04-01","end_date":"2017-11-30","type":"LGFS","description":"LGFS
         Fee Scheme 2016-04"}'
     http_version: 
-  recorded_at: Sun, 29 Jul 2018 13:26:55 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:58 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/2/advocate-types/
@@ -199,7 +199,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - laa-fee-calculator-client/0.1.1
+      - laa-fee-calculator-client/0.1.2
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -208,7 +208,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 29 Jul 2018 13:26:55 GMT
+      - Thu, 23 Aug 2018 10:33:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -225,5 +225,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":0,"next":null,"previous":null,"results":[]}'
     http_version: 
-  recorded_at: Sun, 29 Jul 2018 13:26:55 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:58 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr/client_spec.yml
+++ b/spec/vcr/client_spec.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:14 GMT
+      - Thu, 23 Aug 2018 10:33:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -40,5 +40,5 @@ http_interactions:
         Fee Scheme 10"},{"id":4,"start_date":"2017-12-01","end_date":null,"type":"LGFS","description":"LGFS
         Fee Scheme 2017-12"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:14 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:58 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr/errors_spec.yml
+++ b/spec/vcr/errors_spec.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:20 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -36,7 +36,7 @@ http_interactions:
       encoding: UTF-8
       string: '["`case_date` should be in the format YYYY-MM-DD"]'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:20 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/100/
@@ -56,7 +56,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:20 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -73,7 +73,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:20 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/
@@ -93,7 +93,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:20 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -114,7 +114,7 @@ http_interactions:
         Fee Scheme 10"},{"id":4,"start_date":"2017-12-01","end_date":null,"type":"LGFS","description":"LGFS
         Fee Scheme 2017-12"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:20 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/fee-types/1000/
@@ -134,7 +134,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:20 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -151,7 +151,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:20 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/fee-types/?scenario=INVALID_DATATYPE
@@ -171,7 +171,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:20 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -188,7 +188,7 @@ http_interactions:
       encoding: UTF-8
       string: '["''INVALID_DATATYPE'' is not a valid `scenario`"]'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:20 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/fee-types/?scenario=100
@@ -208,7 +208,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:20 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -225,7 +225,7 @@ http_interactions:
       encoding: UTF-8
       string: '["''100'' is not a valid `scenario`"]'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:20 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/units/1000/
@@ -245,7 +245,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:20 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -262,7 +262,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:20 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/units/?scenario=INVALID_DATATYPE
@@ -282,7 +282,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:20 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -299,7 +299,7 @@ http_interactions:
       encoding: UTF-8
       string: '["''INVALID_DATATYPE'' is not a valid `scenario`"]'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:20 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/units/?scenario=100
@@ -319,7 +319,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:20 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -336,7 +336,7 @@ http_interactions:
       encoding: UTF-8
       string: '["''100'' is not a valid `scenario`"]'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:20 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/modifier-types/1000/
@@ -356,7 +356,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:20 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -373,7 +373,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:20 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/modifier-types/?scenario=INVALID_DATATYPE
@@ -393,7 +393,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:20 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -410,7 +410,7 @@ http_interactions:
       encoding: UTF-8
       string: '["''INVALID_DATATYPE'' is not a valid `scenario`"]'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:20 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/modifier-types/?scenario=100
@@ -430,7 +430,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:20 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -447,7 +447,7 @@ http_interactions:
       encoding: UTF-8
       string: '["''100'' is not a valid `scenario`"]'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:20 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2018-01-01&type=AGFS
@@ -467,7 +467,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:20 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -485,7 +485,7 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
         Fee Scheme 9"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:20 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -505,7 +505,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:20 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -522,7 +522,7 @@ http_interactions:
       encoding: UTF-8
       string: '["`fee_type_code` is a required field"]'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:20 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -542,7 +542,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:20 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -559,7 +559,7 @@ http_interactions:
       encoding: UTF-8
       string: '["`fee_type_code` is a required field"]'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:20 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario
@@ -579,7 +579,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:20 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -596,7 +596,7 @@ http_interactions:
       encoding: UTF-8
       string: '["`scenario` is a required field"]'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:20 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class&scenario=5
@@ -616,7 +616,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -633,7 +633,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":130.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -653,7 +653,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -670,7 +670,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":0.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=100
@@ -690,7 +690,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -707,7 +707,7 @@ http_interactions:
       encoding: UTF-8
       string: '["''100'' is not a valid `scenario`"]'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=INVALID_FEE_TYPE_CODE&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -727,7 +727,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -744,7 +744,7 @@ http_interactions:
       encoding: UTF-8
       string: '["''INVALID_FEE_TYPE_CODE'' is not a valid `fee_type_code`"]'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=INVALID_OFFENCE_CLASS&scenario=5
@@ -764,7 +764,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -781,7 +781,7 @@ http_interactions:
       encoding: UTF-8
       string: '["''INVALID_OFFENCE_CLASS'' is not a valid `offence_class`"]'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=INVALID_ADVOCATE_TYPE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -801,7 +801,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -818,7 +818,7 @@ http_interactions:
       encoding: UTF-8
       string: '["''INVALID_ADVOCATE_TYPE'' is not a valid `advocate_type`"]'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&defendant=2&fee_type_code=AGFS_APPEAL_CON&fixed=2&halfday=2&hour=2&not_a_real_param=rubbish&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -838,7 +838,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -855,5 +855,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":130.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr/fee_scheme_spec.yml
+++ b/spec/vcr/fee_scheme_spec.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:14 GMT
+      - Thu, 23 Aug 2018 10:33:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -36,5 +36,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":130.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:14 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:58 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr/fee_schemes_spec.yml
+++ b/spec/vcr/fee_schemes_spec.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -40,7 +40,7 @@ http_interactions:
         Fee Scheme 10"},{"id":4,"start_date":"2017-12-01","end_date":null,"type":"LGFS","description":"LGFS
         Fee Scheme 2017-12"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/
@@ -60,7 +60,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -78,7 +78,7 @@ http_interactions:
       string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
         Fee Scheme 9"}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/?type=AGFS
@@ -98,7 +98,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -117,7 +117,7 @@ http_interactions:
         Fee Scheme 9"},{"id":3,"start_date":"2018-04-01","end_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 10"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2018-01-01
@@ -137,7 +137,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -156,7 +156,7 @@ http_interactions:
         Fee Scheme 9"},{"id":4,"start_date":"2017-12-01","end_date":null,"type":"LGFS","description":"LGFS
         Fee Scheme 2017-12"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2018-01-01&type=LGFS
@@ -176,7 +176,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -194,5 +194,5 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":4,"start_date":"2017-12-01","end_date":null,"type":"LGFS","description":"LGFS
         Fee Scheme 2017-12"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr/fee_types_spec.yml
+++ b/spec/vcr/fee_types_spec.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
         Fee Scheme 9"}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/fee-types/
@@ -57,7 +57,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -110,7 +110,7 @@ http_interactions:
         relating to admissibility of evidence (half day)","code":"AGFS_ADM_EVD_HF","is_basic":false,"aggregation":"sum"},{"id":91,"name":"Wasted
         preparation fee","code":"AGFS_WSTD_PREP","is_basic":false,"aggregation":"sum"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/fee-types/4/
@@ -130,7 +130,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:38 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -147,7 +147,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"id":4,"name":"Plea and case management hearing","code":"AGFS_PLEA","is_basic":false,"aggregation":"sum"}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:38 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/fee-types/?is_basic=true
@@ -167,7 +167,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:39 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -185,7 +185,7 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":34,"name":"Advocate
         fee","code":"AGFS_FEE","is_basic":true,"aggregation":"sum"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:39 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/fee-types/?scenario=1
@@ -205,7 +205,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:39 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -217,29 +217,23 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '4205'
+      - '3498'
     body:
       encoding: UTF-8
-      string: '{"count":36,"next":null,"previous":null,"results":[{"id":4,"name":"Plea
+      string: '{"count":30,"next":null,"previous":null,"results":[{"id":4,"name":"Plea
         and case management hearing","code":"AGFS_PLEA","is_basic":false,"aggregation":"sum"},{"id":5,"name":"Abuse
         of process hearing (half day)","code":"AGFS_ABS_PRC_HF","is_basic":false,"aggregation":"sum"},{"id":6,"name":"Abuse
         of process hearing (full day)","code":"AGFS_ABS_PRC_WL","is_basic":false,"aggregation":"sum"},{"id":7,"name":"Adjourned
-        appeals","code":"AGFS_ADJOURNED","is_basic":false,"aggregation":"sum"},{"id":8,"name":"Appeals
-        to crown court against conviction","code":"AGFS_APPEAL_CON","is_basic":false,"aggregation":"sum"},{"id":9,"name":"Appeals
-        to the crown court against sentence","code":"AGFS_APPEAL_SEN","is_basic":false,"aggregation":"sum"},{"id":10,"name":"Application
+        appeals","code":"AGFS_ADJOURNED","is_basic":false,"aggregation":"sum"},{"id":10,"name":"Application
         to dismiss a charge day 2 onwards (half day)","code":"AGFS_DMS_DY2_HF","is_basic":false,"aggregation":"sum"},{"id":11,"name":"Application
-        to dismiss a charge day 2 onwards (full day)","code":"AGFS_DMS_DY2_WL","is_basic":false,"aggregation":"sum"},{"id":12,"name":"Committal
-        for sentence hearing","code":"AGFS_COMMITTAL","is_basic":false,"aggregation":"sum"},{"id":13,"name":"Conferences
-        and views (hours)","code":"AGFS_CONFERENCE","is_basic":false,"aggregation":"sum"},{"id":14,"name":"Contempt
-        hearings","code":"AGFS_CONTEMPT","is_basic":false,"aggregation":"sum"},{"id":15,"name":"Contempt
-        hearings (apportioned)","code":"AGFS_CNTMPT_APP","is_basic":false,"aggregation":"sum"},{"id":16,"name":"Deferred
+        to dismiss a charge day 2 onwards (full day)","code":"AGFS_DMS_DY2_WL","is_basic":false,"aggregation":"sum"},{"id":13,"name":"Conferences
+        and views (hours)","code":"AGFS_CONFERENCE","is_basic":false,"aggregation":"sum"},{"id":16,"name":"Deferred
         sentence hearings","code":"AGFS_DEF_SEN_HR","is_basic":false,"aggregation":"sum"},{"id":17,"name":"Hearings
         relating to admissibility of evidence (full day)","code":"AGFS_ADM_EVD_WL","is_basic":false,"aggregation":"sum"},{"id":18,"name":"Hearings
         relating to disclosure (half day)","code":"AGFS_DISC_HALF","is_basic":false,"aggregation":"sum"},{"id":19,"name":"Hearings
         relating to disclosure (full day)","code":"AGFS_DISC_FULL","is_basic":false,"aggregation":"sum"},{"id":20,"name":"Noting
         brief","code":"AGFS_NOTING_BRF","is_basic":false,"aggregation":"sum"},{"id":21,"name":"Paper
-        plea and case management","code":"AGFS_PAPER_PLEA","is_basic":false,"aggregation":"sum"},{"id":22,"name":"Proceeds
-        relating to breach of an order of the crown court","code":"AGFS_ORDER_BRCH","is_basic":false,"aggregation":"sum"},{"id":23,"name":"Public
+        plea and case management","code":"AGFS_PAPER_PLEA","is_basic":false,"aggregation":"sum"},{"id":23,"name":"Public
         interest immunity hearing (half day)","code":"AGFS_PI_IMMN_HF","is_basic":false,"aggregation":"sum"},{"id":24,"name":"Public
         interest immunity hearing (full day)","code":"AGFS_PI_IMMN_WL","is_basic":false,"aggregation":"sum"},{"id":25,"name":"Research
         of very unusual or novel factual issue","code":"AGFS_NOVELISSUE","is_basic":false,"aggregation":"sum"},{"id":26,"name":"Research
@@ -258,7 +252,7 @@ http_interactions:
         relating to admissibility of evidence (half day)","code":"AGFS_ADM_EVD_HF","is_basic":false,"aggregation":"sum"},{"id":91,"name":"Wasted
         preparation fee","code":"AGFS_WSTD_PREP","is_basic":false,"aggregation":"sum"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:39 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/fee-types/?advocate_type=QC
@@ -278,7 +272,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:39 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -331,7 +325,7 @@ http_interactions:
         relating to admissibility of evidence (half day)","code":"AGFS_ADM_EVD_HF","is_basic":false,"aggregation":"sum"},{"id":91,"name":"Wasted
         preparation fee","code":"AGFS_WSTD_PREP","is_basic":false,"aggregation":"sum"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:39 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/fee-types/?offence_class=A
@@ -351,7 +345,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:39 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -404,7 +398,7 @@ http_interactions:
         relating to admissibility of evidence (half day)","code":"AGFS_ADM_EVD_HF","is_basic":false,"aggregation":"sum"},{"id":91,"name":"Wasted
         preparation fee","code":"AGFS_WSTD_PREP","is_basic":false,"aggregation":"sum"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:39 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/fee-types/?fee_type_code=AGFS_FEE
@@ -424,7 +418,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:39 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -442,7 +436,7 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":34,"name":"Advocate
         fee","code":"AGFS_FEE","is_basic":true,"aggregation":"sum"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:39 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/fee-types/1001/
@@ -462,7 +456,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:39 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -479,7 +473,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:39 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/fee-types/?is_basic=true&scenario=8
@@ -499,7 +493,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:39 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -516,77 +510,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":0,"next":null,"previous":null,"results":[]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:39 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/1/fee-types/?is_basic=false&scenario=8
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/0.1.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 30 Jul 2018 11:15:39 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.6.5
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '3909'
-    body:
-      encoding: UTF-8
-      string: '{"count":33,"next":null,"previous":null,"results":[{"id":4,"name":"Plea
-        and case management hearing","code":"AGFS_PLEA","is_basic":false,"aggregation":"sum"},{"id":5,"name":"Abuse
-        of process hearing (half day)","code":"AGFS_ABS_PRC_HF","is_basic":false,"aggregation":"sum"},{"id":6,"name":"Abuse
-        of process hearing (full day)","code":"AGFS_ABS_PRC_WL","is_basic":false,"aggregation":"sum"},{"id":7,"name":"Adjourned
-        appeals","code":"AGFS_ADJOURNED","is_basic":false,"aggregation":"sum"},{"id":8,"name":"Appeals
-        to crown court against conviction","code":"AGFS_APPEAL_CON","is_basic":false,"aggregation":"sum"},{"id":9,"name":"Appeals
-        to the crown court against sentence","code":"AGFS_APPEAL_SEN","is_basic":false,"aggregation":"sum"},{"id":10,"name":"Application
-        to dismiss a charge day 2 onwards (half day)","code":"AGFS_DMS_DY2_HF","is_basic":false,"aggregation":"sum"},{"id":11,"name":"Application
-        to dismiss a charge day 2 onwards (full day)","code":"AGFS_DMS_DY2_WL","is_basic":false,"aggregation":"sum"},{"id":12,"name":"Committal
-        for sentence hearing","code":"AGFS_COMMITTAL","is_basic":false,"aggregation":"sum"},{"id":13,"name":"Conferences
-        and views (hours)","code":"AGFS_CONFERENCE","is_basic":false,"aggregation":"sum"},{"id":14,"name":"Contempt
-        hearings","code":"AGFS_CONTEMPT","is_basic":false,"aggregation":"sum"},{"id":15,"name":"Contempt
-        hearings (apportioned)","code":"AGFS_CNTMPT_APP","is_basic":false,"aggregation":"sum"},{"id":16,"name":"Deferred
-        sentence hearings","code":"AGFS_DEF_SEN_HR","is_basic":false,"aggregation":"sum"},{"id":17,"name":"Hearings
-        relating to admissibility of evidence (full day)","code":"AGFS_ADM_EVD_WL","is_basic":false,"aggregation":"sum"},{"id":18,"name":"Hearings
-        relating to disclosure (half day)","code":"AGFS_DISC_HALF","is_basic":false,"aggregation":"sum"},{"id":19,"name":"Hearings
-        relating to disclosure (full day)","code":"AGFS_DISC_FULL","is_basic":false,"aggregation":"sum"},{"id":20,"name":"Noting
-        brief","code":"AGFS_NOTING_BRF","is_basic":false,"aggregation":"sum"},{"id":21,"name":"Paper
-        plea and case management","code":"AGFS_PAPER_PLEA","is_basic":false,"aggregation":"sum"},{"id":22,"name":"Proceeds
-        relating to breach of an order of the crown court","code":"AGFS_ORDER_BRCH","is_basic":false,"aggregation":"sum"},{"id":23,"name":"Public
-        interest immunity hearing (half day)","code":"AGFS_PI_IMMN_HF","is_basic":false,"aggregation":"sum"},{"id":24,"name":"Public
-        interest immunity hearing (full day)","code":"AGFS_PI_IMMN_WL","is_basic":false,"aggregation":"sum"},{"id":25,"name":"Research
-        of very unusual or novel factual issue","code":"AGFS_NOVELISSUE","is_basic":false,"aggregation":"sum"},{"id":26,"name":"Research
-        of very unusual of novel point of law","code":"AGFS_NOVEL_LAW","is_basic":false,"aggregation":"sum"},{"id":27,"name":"Standard
-        appearance fee","code":"AGFS_STD_APPRNC","is_basic":false,"aggregation":"sum"},{"id":28,"name":"Sentence
-        hearing","code":"AGFS_SENTENCE","is_basic":false,"aggregation":"sum"},{"id":29,"name":"Special
-        preperation (hourly)","code":"AGFS_SPCL_PREP","is_basic":false,"aggregation":"sum"},{"id":30,"name":"Trial
-        not proceed","code":"AGFS_NOT_PRCD","is_basic":false,"aggregation":"sum"},{"id":31,"name":"Unsuccesful
-        application to vacate a guilty plea (half day)","code":"AGFS_UN_VAC_HF","is_basic":false,"aggregation":"sum"},{"id":32,"name":"Unsuccesful
-        application to vacate a guilty plea (full day)","code":"AGFS_UN_VAC_WL","is_basic":false,"aggregation":"sum"},{"id":33,"name":"Written
-        / oral advice","code":"AGFS_WRTN_ORAL","is_basic":false,"aggregation":"sum"},{"id":36,"name":"Staged
-        payments","code":"AGFS_STAGED","is_basic":false,"aggregation":"sum"},{"id":90,"name":"Hearings
-        relating to admissibility of evidence (half day)","code":"AGFS_ADM_EVD_HF","is_basic":false,"aggregation":"sum"},{"id":91,"name":"Wasted
-        preparation fee","code":"AGFS_WSTD_PREP","is_basic":false,"aggregation":"sum"}]}'
-    http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:39 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/fee-types/?scenario=8
@@ -606,7 +530,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:39 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -618,19 +542,16 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '3909'
+      - '3412'
     body:
       encoding: UTF-8
-      string: '{"count":33,"next":null,"previous":null,"results":[{"id":4,"name":"Plea
+      string: '{"count":29,"next":null,"previous":null,"results":[{"id":4,"name":"Plea
         and case management hearing","code":"AGFS_PLEA","is_basic":false,"aggregation":"sum"},{"id":5,"name":"Abuse
         of process hearing (half day)","code":"AGFS_ABS_PRC_HF","is_basic":false,"aggregation":"sum"},{"id":6,"name":"Abuse
         of process hearing (full day)","code":"AGFS_ABS_PRC_WL","is_basic":false,"aggregation":"sum"},{"id":7,"name":"Adjourned
-        appeals","code":"AGFS_ADJOURNED","is_basic":false,"aggregation":"sum"},{"id":8,"name":"Appeals
-        to crown court against conviction","code":"AGFS_APPEAL_CON","is_basic":false,"aggregation":"sum"},{"id":9,"name":"Appeals
-        to the crown court against sentence","code":"AGFS_APPEAL_SEN","is_basic":false,"aggregation":"sum"},{"id":10,"name":"Application
+        appeals","code":"AGFS_ADJOURNED","is_basic":false,"aggregation":"sum"},{"id":10,"name":"Application
         to dismiss a charge day 2 onwards (half day)","code":"AGFS_DMS_DY2_HF","is_basic":false,"aggregation":"sum"},{"id":11,"name":"Application
-        to dismiss a charge day 2 onwards (full day)","code":"AGFS_DMS_DY2_WL","is_basic":false,"aggregation":"sum"},{"id":12,"name":"Committal
-        for sentence hearing","code":"AGFS_COMMITTAL","is_basic":false,"aggregation":"sum"},{"id":13,"name":"Conferences
+        to dismiss a charge day 2 onwards (full day)","code":"AGFS_DMS_DY2_WL","is_basic":false,"aggregation":"sum"},{"id":13,"name":"Conferences
         and views (hours)","code":"AGFS_CONFERENCE","is_basic":false,"aggregation":"sum"},{"id":14,"name":"Contempt
         hearings","code":"AGFS_CONTEMPT","is_basic":false,"aggregation":"sum"},{"id":15,"name":"Contempt
         hearings (apportioned)","code":"AGFS_CNTMPT_APP","is_basic":false,"aggregation":"sum"},{"id":16,"name":"Deferred
@@ -639,8 +560,7 @@ http_interactions:
         relating to disclosure (half day)","code":"AGFS_DISC_HALF","is_basic":false,"aggregation":"sum"},{"id":19,"name":"Hearings
         relating to disclosure (full day)","code":"AGFS_DISC_FULL","is_basic":false,"aggregation":"sum"},{"id":20,"name":"Noting
         brief","code":"AGFS_NOTING_BRF","is_basic":false,"aggregation":"sum"},{"id":21,"name":"Paper
-        plea and case management","code":"AGFS_PAPER_PLEA","is_basic":false,"aggregation":"sum"},{"id":22,"name":"Proceeds
-        relating to breach of an order of the crown court","code":"AGFS_ORDER_BRCH","is_basic":false,"aggregation":"sum"},{"id":23,"name":"Public
+        plea and case management","code":"AGFS_PAPER_PLEA","is_basic":false,"aggregation":"sum"},{"id":23,"name":"Public
         interest immunity hearing (half day)","code":"AGFS_PI_IMMN_HF","is_basic":false,"aggregation":"sum"},{"id":24,"name":"Public
         interest immunity hearing (full day)","code":"AGFS_PI_IMMN_WL","is_basic":false,"aggregation":"sum"},{"id":25,"name":"Research
         of very unusual or novel factual issue","code":"AGFS_NOVELISSUE","is_basic":false,"aggregation":"sum"},{"id":26,"name":"Research
@@ -656,5 +576,5 @@ http_interactions:
         relating to admissibility of evidence (half day)","code":"AGFS_ADM_EVD_HF","is_basic":false,"aggregation":"sum"},{"id":91,"name":"Wasted
         preparation fee","code":"AGFS_WSTD_PREP","is_basic":false,"aggregation":"sum"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:39 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr/fixed_fees_spec.yml
+++ b/spec/vcr/fixed_fees_spec.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:14 GMT
+      - Thu, 23 Aug 2018 10:33:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
         Fee Scheme 9"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:14 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:58 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -57,7 +57,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:14 GMT
+      - Thu, 23 Aug 2018 10:33:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -74,7 +74,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":130.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:14 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:58 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -94,7 +94,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:14 GMT
+      - Thu, 23 Aug 2018 10:33:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -111,7 +111,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":130.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:14 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:58 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -131,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:14 GMT
+      - Thu, 23 Aug 2018 10:33:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -148,7 +148,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":195.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:14 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:58 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -168,7 +168,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:14 GMT
+      - Thu, 23 Aug 2018 10:33:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -185,7 +185,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":260.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:14 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:58 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=INVALID&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -205,7 +205,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:14 GMT
+      - Thu, 23 Aug 2018 10:33:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -222,7 +222,7 @@ http_interactions:
       encoding: UTF-8
       string: '["''INVALID'' is not a valid `advocate_type`"]'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:14 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:58 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=30&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -242,7 +242,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:14 GMT
+      - Thu, 23 Aug 2018 10:33:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -259,7 +259,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":3900.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:14 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:58 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=31&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -279,7 +279,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:14 GMT
+      - Thu, 23 Aug 2018 10:33:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -296,7 +296,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":3900.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:14 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:58 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=2&offence_class=E&scenario=5
@@ -316,7 +316,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:14 GMT
+      - Thu, 23 Aug 2018 10:33:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -333,7 +333,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":156.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:14 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:58 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=3&offence_class=E&scenario=5
@@ -353,7 +353,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:14 GMT
+      - Thu, 23 Aug 2018 10:33:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -370,7 +370,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":182.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:14 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:58 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=4&offence_class=E&scenario=5
@@ -390,7 +390,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:14 GMT
+      - Thu, 23 Aug 2018 10:33:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -407,7 +407,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":208.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:14 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:58 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=5&offence_class=E&scenario=5
@@ -427,7 +427,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:14 GMT
+      - Thu, 23 Aug 2018 10:33:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -444,7 +444,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":234.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:14 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:58 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=10&offence_class=E&scenario=5
@@ -464,7 +464,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:14 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -481,7 +481,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":364.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:14 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=100&offence_class=E&scenario=5
@@ -501,7 +501,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:14 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -518,7 +518,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2704.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:14 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=2&number_of_defendants=1&offence_class=E&scenario=5
@@ -538,7 +538,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:14 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -555,7 +555,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":156.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:14 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=3&number_of_defendants=1&offence_class=E&scenario=5
@@ -575,7 +575,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:14 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -592,7 +592,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":182.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:14 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=4&number_of_defendants=1&offence_class=E&scenario=5
@@ -612,7 +612,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:15 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -629,7 +629,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":208.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:15 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=5&number_of_defendants=1&offence_class=E&scenario=5
@@ -649,7 +649,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:15 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -666,7 +666,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":234.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:15 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=10&number_of_defendants=1&offence_class=E&scenario=5
@@ -686,7 +686,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:15 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -703,7 +703,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":364.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:15 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=100&number_of_defendants=1&offence_class=E&scenario=5
@@ -723,7 +723,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:15 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -740,7 +740,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2704.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:15 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2018-01-01&type=LGFS
@@ -760,7 +760,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:31 GMT
+      - Thu, 23 Aug 2018 10:34:14 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -778,7 +778,7 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":4,"start_date":"2017-12-01","end_date":null,"type":"LGFS","description":"LGFS
         Fee Scheme 2017-12"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:31 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:14 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -798,7 +798,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:31 GMT
+      - Thu, 23 Aug 2018 10:34:14 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -815,7 +815,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":349.47}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:31 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:14 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=10&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -835,7 +835,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:31 GMT
+      - Thu, 23 Aug 2018 10:34:14 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -852,7 +852,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":349.47}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:31 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:14 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=100&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -872,7 +872,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:32 GMT
+      - Thu, 23 Aug 2018 10:34:14 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -889,7 +889,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":349.47}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:32 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:14 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=10&offence_class=E&scenario=5
@@ -909,7 +909,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:32 GMT
+      - Thu, 23 Aug 2018 10:34:14 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -926,7 +926,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":349.47}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:32 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:14 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=10&number_of_defendants=1&offence_class=E&scenario=5
@@ -946,7 +946,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:32 GMT
+      - Thu, 23 Aug 2018 10:34:15 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -963,5 +963,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":349.47}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:32 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:15 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr/graduated_fees_spec.yml
+++ b/spec/vcr/graduated_fees_spec.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:15 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
         Fee Scheme 9"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:15 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -57,7 +57,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:15 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -74,7 +74,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1632.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:15 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=2&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -94,7 +94,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:15 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -111,7 +111,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1632.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:15 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -131,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:15 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -148,7 +148,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":3835.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:15 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -168,7 +168,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:15 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -185,7 +185,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":40058.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:15 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=1&pw=1&scenario=4
@@ -205,7 +205,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:15 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -222,7 +222,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":3386.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:15 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=1&pw=1&scenario=4
@@ -242,7 +242,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:15 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -259,7 +259,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":35095.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:15 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=C&ppe=1&pw=1&scenario=4
@@ -279,7 +279,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:15 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -296,7 +296,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2784.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:15 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=C&ppe=1&pw=1&scenario=4
@@ -316,7 +316,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:15 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -333,7 +333,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":32976.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:15 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=D&ppe=1&pw=1&scenario=4
@@ -353,7 +353,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:15 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -370,7 +370,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":3100.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:15 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=D&ppe=1&pw=1&scenario=4
@@ -390,7 +390,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:15 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -407,7 +407,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":33292.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:15 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&ppe=1&pw=1&scenario=4
@@ -427,7 +427,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:15 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -444,7 +444,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2126.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:15 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&ppe=1&pw=1&scenario=4
@@ -464,7 +464,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:15 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -481,7 +481,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":24770.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:15 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=F&ppe=1&pw=1&scenario=4
@@ -501,7 +501,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:15 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -518,7 +518,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2126.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:15 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=F&ppe=1&pw=1&scenario=4
@@ -538,7 +538,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:15 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -555,7 +555,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":24770.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:15 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=G&ppe=1&pw=1&scenario=4
@@ -575,7 +575,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:16 GMT
+      - Thu, 23 Aug 2018 10:33:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -592,7 +592,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2126.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:16 GMT
+  recorded_at: Thu, 23 Aug 2018 10:33:59 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=G&ppe=1&pw=1&scenario=4
@@ -612,7 +612,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:16 GMT
+      - Thu, 23 Aug 2018 10:34:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -629,7 +629,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":24770.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:16 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=H&ppe=1&pw=1&scenario=4
@@ -649,7 +649,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:16 GMT
+      - Thu, 23 Aug 2018 10:34:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -666,7 +666,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2719.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:16 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=H&ppe=1&pw=1&scenario=4
@@ -686,7 +686,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:16 GMT
+      - Thu, 23 Aug 2018 10:34:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -703,7 +703,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":32911.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:16 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=I&ppe=1&pw=1&scenario=4
@@ -723,7 +723,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:16 GMT
+      - Thu, 23 Aug 2018 10:34:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -740,7 +740,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2938.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:16 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=I&ppe=1&pw=1&scenario=4
@@ -760,7 +760,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:16 GMT
+      - Thu, 23 Aug 2018 10:34:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -777,7 +777,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":33130.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:16 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=J&ppe=1&pw=1&scenario=4
@@ -797,7 +797,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:16 GMT
+      - Thu, 23 Aug 2018 10:34:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -814,7 +814,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":3835.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:16 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=J&ppe=1&pw=1&scenario=4
@@ -834,7 +834,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:16 GMT
+      - Thu, 23 Aug 2018 10:34:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -851,7 +851,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":40058.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:16 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=K&ppe=1&pw=1&scenario=4
@@ -871,7 +871,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:16 GMT
+      - Thu, 23 Aug 2018 10:34:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -888,7 +888,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":3835.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:16 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=K&ppe=1&pw=1&scenario=4
@@ -908,7 +908,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:16 GMT
+      - Thu, 23 Aug 2018 10:34:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -925,7 +925,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":40058.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:16 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -945,7 +945,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:16 GMT
+      - Thu, 23 Aug 2018 10:34:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -962,7 +962,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2876.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:16 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -982,7 +982,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:16 GMT
+      - Thu, 23 Aug 2018 10:34:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -999,7 +999,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":30034.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:16 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=1&pw=1&scenario=4
@@ -1019,7 +1019,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:16 GMT
+      - Thu, 23 Aug 2018 10:34:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1036,7 +1036,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2540.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:16 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=1&pw=1&scenario=4
@@ -1056,7 +1056,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:16 GMT
+      - Thu, 23 Aug 2018 10:34:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1073,7 +1073,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":26331.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:16 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=C&ppe=1&pw=1&scenario=4
@@ -1093,7 +1093,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:16 GMT
+      - Thu, 23 Aug 2018 10:34:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1110,7 +1110,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2088.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:16 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=C&ppe=1&pw=1&scenario=4
@@ -1130,7 +1130,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:16 GMT
+      - Thu, 23 Aug 2018 10:34:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1147,7 +1147,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":24732.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:16 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=D&ppe=1&pw=1&scenario=4
@@ -1167,7 +1167,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:17 GMT
+      - Thu, 23 Aug 2018 10:34:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1184,7 +1184,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2326.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:17 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=D&ppe=1&pw=1&scenario=4
@@ -1204,7 +1204,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:17 GMT
+      - Thu, 23 Aug 2018 10:34:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1221,7 +1221,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":24970.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:17 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&ppe=1&pw=1&scenario=4
@@ -1241,7 +1241,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:17 GMT
+      - Thu, 23 Aug 2018 10:34:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1258,7 +1258,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1595.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:17 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&ppe=1&pw=1&scenario=4
@@ -1278,7 +1278,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:17 GMT
+      - Thu, 23 Aug 2018 10:34:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1295,7 +1295,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":18578.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:17 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:01 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=F&ppe=1&pw=1&scenario=4
@@ -1315,7 +1315,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:17 GMT
+      - Thu, 23 Aug 2018 10:34:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1332,7 +1332,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1595.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:17 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:01 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=F&ppe=1&pw=1&scenario=4
@@ -1352,7 +1352,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:17 GMT
+      - Thu, 23 Aug 2018 10:34:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1369,7 +1369,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":18578.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:17 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:01 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=G&ppe=1&pw=1&scenario=4
@@ -1389,7 +1389,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:17 GMT
+      - Thu, 23 Aug 2018 10:34:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1406,7 +1406,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1595.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:17 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:01 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=G&ppe=1&pw=1&scenario=4
@@ -1426,7 +1426,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:17 GMT
+      - Thu, 23 Aug 2018 10:34:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1443,7 +1443,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":18578.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:17 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:01 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=H&ppe=1&pw=1&scenario=4
@@ -1463,7 +1463,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:17 GMT
+      - Thu, 23 Aug 2018 10:34:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1480,7 +1480,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2039.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:17 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:01 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=H&ppe=1&pw=1&scenario=4
@@ -1500,7 +1500,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:17 GMT
+      - Thu, 23 Aug 2018 10:34:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1517,7 +1517,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":24683.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:17 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:01 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=I&ppe=1&pw=1&scenario=4
@@ -1537,7 +1537,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:17 GMT
+      - Thu, 23 Aug 2018 10:34:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1554,7 +1554,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2204.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:17 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:01 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=I&ppe=1&pw=1&scenario=4
@@ -1574,7 +1574,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:17 GMT
+      - Thu, 23 Aug 2018 10:34:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1591,7 +1591,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":24848.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:17 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:01 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=J&ppe=1&pw=1&scenario=4
@@ -1611,7 +1611,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:18 GMT
+      - Thu, 23 Aug 2018 10:34:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1628,7 +1628,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2876.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:18 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:01 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=J&ppe=1&pw=1&scenario=4
@@ -1648,7 +1648,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:18 GMT
+      - Thu, 23 Aug 2018 10:34:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1665,7 +1665,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":30034.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:18 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:01 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=K&ppe=1&pw=1&scenario=4
@@ -1685,7 +1685,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:18 GMT
+      - Thu, 23 Aug 2018 10:34:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1702,7 +1702,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2876.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:18 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:01 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=K&ppe=1&pw=1&scenario=4
@@ -1722,7 +1722,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:18 GMT
+      - Thu, 23 Aug 2018 10:34:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1739,7 +1739,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":30034.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:18 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:01 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -1759,7 +1759,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:18 GMT
+      - Thu, 23 Aug 2018 10:34:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1776,7 +1776,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2122.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:18 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:01 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -1796,7 +1796,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:18 GMT
+      - Thu, 23 Aug 2018 10:34:02 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1813,7 +1813,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":20252.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:18 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:02 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=1&pw=1&scenario=4
@@ -1833,7 +1833,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:18 GMT
+      - Thu, 23 Aug 2018 10:34:02 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1850,7 +1850,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1693.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:18 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:02 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=1&pw=1&scenario=4
@@ -1870,7 +1870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:18 GMT
+      - Thu, 23 Aug 2018 10:34:02 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1887,7 +1887,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":17529.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:18 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:02 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=C&ppe=1&pw=1&scenario=4
@@ -1907,7 +1907,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:18 GMT
+      - Thu, 23 Aug 2018 10:34:02 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1924,7 +1924,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1306.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:18 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:02 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=C&ppe=1&pw=1&scenario=4
@@ -1944,7 +1944,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:18 GMT
+      - Thu, 23 Aug 2018 10:34:02 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1961,7 +1961,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":16402.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:18 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:02 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=D&ppe=1&pw=1&scenario=4
@@ -1981,7 +1981,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:18 GMT
+      - Thu, 23 Aug 2018 10:34:02 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1998,7 +1998,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1533.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:18 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:02 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=D&ppe=1&pw=1&scenario=4
@@ -2018,7 +2018,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:18 GMT
+      - Thu, 23 Aug 2018 10:34:02 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2035,7 +2035,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":16629.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:18 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:02 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&ppe=1&pw=1&scenario=4
@@ -2055,7 +2055,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:19 GMT
+      - Thu, 23 Aug 2018 10:34:02 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2072,7 +2072,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1000.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:19 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:02 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&ppe=1&pw=1&scenario=4
@@ -2092,7 +2092,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:19 GMT
+      - Thu, 23 Aug 2018 10:34:02 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2109,7 +2109,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":12322.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:19 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:02 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=F&ppe=1&pw=1&scenario=4
@@ -2129,7 +2129,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:19 GMT
+      - Thu, 23 Aug 2018 10:34:02 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2146,7 +2146,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1000.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:19 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:02 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=F&ppe=1&pw=1&scenario=4
@@ -2166,7 +2166,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:19 GMT
+      - Thu, 23 Aug 2018 10:34:02 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2183,7 +2183,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":12322.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:19 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:02 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=G&ppe=1&pw=1&scenario=4
@@ -2203,7 +2203,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:19 GMT
+      - Thu, 23 Aug 2018 10:34:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2220,7 +2220,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1000.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:19 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:03 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=G&ppe=1&pw=1&scenario=4
@@ -2240,7 +2240,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:19 GMT
+      - Thu, 23 Aug 2018 10:34:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2257,7 +2257,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":12322.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:19 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:03 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=H&ppe=1&pw=1&scenario=4
@@ -2277,7 +2277,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:19 GMT
+      - Thu, 23 Aug 2018 10:34:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2294,7 +2294,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1224.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:19 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:03 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=H&ppe=1&pw=1&scenario=4
@@ -2314,7 +2314,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:19 GMT
+      - Thu, 23 Aug 2018 10:34:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2331,7 +2331,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":16320.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:19 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:03 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=I&ppe=1&pw=1&scenario=4
@@ -2351,7 +2351,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:19 GMT
+      - Thu, 23 Aug 2018 10:34:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2368,7 +2368,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1387.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:19 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:03 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=I&ppe=1&pw=1&scenario=4
@@ -2388,7 +2388,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:19 GMT
+      - Thu, 23 Aug 2018 10:34:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2405,7 +2405,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":16483.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:19 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:03 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=J&ppe=1&pw=1&scenario=4
@@ -2425,7 +2425,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:20 GMT
+      - Thu, 23 Aug 2018 10:34:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2442,7 +2442,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2122.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:20 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:03 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=J&ppe=1&pw=1&scenario=4
@@ -2462,7 +2462,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:20 GMT
+      - Thu, 23 Aug 2018 10:34:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2479,7 +2479,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":20252.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:20 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:03 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=K&ppe=1&pw=1&scenario=4
@@ -2499,7 +2499,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:20 GMT
+      - Thu, 23 Aug 2018 10:34:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2516,7 +2516,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1918.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:20 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:03 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=K&ppe=1&pw=1&scenario=4
@@ -2536,7 +2536,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:20 GMT
+      - Thu, 23 Aug 2018 10:34:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2553,7 +2553,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":20048.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:20 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:03 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -2573,7 +2573,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:20 GMT
+      - Thu, 23 Aug 2018 10:34:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2590,7 +2590,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2162.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:20 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:03 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -2610,7 +2610,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:20 GMT
+      - Thu, 23 Aug 2018 10:34:04 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2627,7 +2627,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":21772.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:20 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:04 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=1&pw=1&scenario=4
@@ -2647,7 +2647,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:20 GMT
+      - Thu, 23 Aug 2018 10:34:04 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2664,7 +2664,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1774.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:20 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:04 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=1&pw=1&scenario=4
@@ -2684,7 +2684,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:20 GMT
+      - Thu, 23 Aug 2018 10:34:04 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2701,7 +2701,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":19127.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:20 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:04 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=C&ppe=1&pw=1&scenario=4
@@ -2721,7 +2721,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:20 GMT
+      - Thu, 23 Aug 2018 10:34:04 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2738,7 +2738,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1306.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:20 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:04 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=C&ppe=1&pw=1&scenario=4
@@ -2758,7 +2758,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:21 GMT
+      - Thu, 23 Aug 2018 10:34:04 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2775,7 +2775,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":16402.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:21 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:04 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=D&ppe=1&pw=1&scenario=4
@@ -2795,7 +2795,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:21 GMT
+      - Thu, 23 Aug 2018 10:34:04 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2812,7 +2812,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1533.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:21 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:04 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=D&ppe=1&pw=1&scenario=4
@@ -2832,7 +2832,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:21 GMT
+      - Thu, 23 Aug 2018 10:34:04 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2849,7 +2849,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":16629.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:21 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:04 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&ppe=1&pw=1&scenario=4
@@ -2869,7 +2869,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:21 GMT
+      - Thu, 23 Aug 2018 10:34:04 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2886,7 +2886,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":979.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:21 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:04 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&ppe=1&pw=1&scenario=4
@@ -2906,7 +2906,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:21 GMT
+      - Thu, 23 Aug 2018 10:34:04 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2923,7 +2923,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":13041.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:21 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:04 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=F&ppe=1&pw=1&scenario=4
@@ -2943,7 +2943,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:21 GMT
+      - Thu, 23 Aug 2018 10:34:04 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2960,7 +2960,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1020.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:21 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:04 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=F&ppe=1&pw=1&scenario=4
@@ -2980,7 +2980,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:21 GMT
+      - Thu, 23 Aug 2018 10:34:05 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -2997,7 +2997,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":13082.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:21 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:05 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=G&ppe=1&pw=1&scenario=4
@@ -3017,7 +3017,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:21 GMT
+      - Thu, 23 Aug 2018 10:34:05 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3034,7 +3034,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1020.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:21 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:05 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=G&ppe=1&pw=1&scenario=4
@@ -3054,7 +3054,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:21 GMT
+      - Thu, 23 Aug 2018 10:34:05 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3071,7 +3071,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":13082.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:21 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:05 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=H&ppe=1&pw=1&scenario=4
@@ -3091,7 +3091,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:22 GMT
+      - Thu, 23 Aug 2018 10:34:05 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3108,7 +3108,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1224.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:22 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:05 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=H&ppe=1&pw=1&scenario=4
@@ -3128,7 +3128,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:22 GMT
+      - Thu, 23 Aug 2018 10:34:05 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3145,7 +3145,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":16320.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:22 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:05 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=I&ppe=1&pw=1&scenario=4
@@ -3165,7 +3165,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:22 GMT
+      - Thu, 23 Aug 2018 10:34:05 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3182,7 +3182,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1387.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:22 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:05 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=I&ppe=1&pw=1&scenario=4
@@ -3202,7 +3202,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:22 GMT
+      - Thu, 23 Aug 2018 10:34:05 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3219,7 +3219,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":16483.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:22 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:05 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=J&ppe=1&pw=1&scenario=4
@@ -3239,7 +3239,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:22 GMT
+      - Thu, 23 Aug 2018 10:34:05 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3256,7 +3256,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2162.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:22 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:05 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=J&ppe=1&pw=1&scenario=4
@@ -3276,7 +3276,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:22 GMT
+      - Thu, 23 Aug 2018 10:34:05 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3293,7 +3293,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":21772.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:22 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:05 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=K&ppe=1&pw=1&scenario=4
@@ -3313,7 +3313,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:22 GMT
+      - Thu, 23 Aug 2018 10:34:06 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3330,7 +3330,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2162.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:22 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:06 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=K&ppe=1&pw=1&scenario=4
@@ -3350,7 +3350,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:22 GMT
+      - Thu, 23 Aug 2018 10:34:06 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3367,7 +3367,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":21772.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:22 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:06 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=9999&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -3387,7 +3387,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:23 GMT
+      - Thu, 23 Aug 2018 10:34:06 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3404,7 +3404,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2859897.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:23 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:06 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=10000&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -3424,7 +3424,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:23 GMT
+      - Thu, 23 Aug 2018 10:34:06 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3441,7 +3441,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2859897.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:23 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:06 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=0&pw=1&scenario=4
@@ -3461,7 +3461,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:23 GMT
+      - Thu, 23 Aug 2018 10:34:06 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3478,7 +3478,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2856.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:23 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:06 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=50&pw=1&scenario=4
@@ -3498,7 +3498,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:23 GMT
+      - Thu, 23 Aug 2018 10:34:06 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3515,7 +3515,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2856.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:23 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:06 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=51&pw=1&scenario=4
@@ -3535,7 +3535,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:23 GMT
+      - Thu, 23 Aug 2018 10:34:06 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3552,7 +3552,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2857.63}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:23 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:06 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=100&pw=1&scenario=4
@@ -3572,7 +3572,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:23 GMT
+      - Thu, 23 Aug 2018 10:34:06 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3589,7 +3589,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2937.5}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:23 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:06 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=10000&pw=1&scenario=4
@@ -3609,7 +3609,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:23 GMT
+      - Thu, 23 Aug 2018 10:34:06 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3626,7 +3626,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":19074.5}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:23 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:06 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=10001&pw=1&scenario=4
@@ -3646,7 +3646,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:23 GMT
+      - Thu, 23 Aug 2018 10:34:07 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3663,7 +3663,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":19074.5}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:23 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:07 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=0&pw=1&scenario=4
@@ -3683,7 +3683,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:24 GMT
+      - Thu, 23 Aug 2018 10:34:07 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3700,7 +3700,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2142.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:24 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:07 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=50&pw=1&scenario=4
@@ -3720,7 +3720,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:24 GMT
+      - Thu, 23 Aug 2018 10:34:07 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3737,7 +3737,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2142.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:24 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:07 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=51&pw=1&scenario=4
@@ -3757,7 +3757,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:24 GMT
+      - Thu, 23 Aug 2018 10:34:07 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3774,7 +3774,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2143.23}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:24 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:07 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=100&pw=1&scenario=4
@@ -3794,7 +3794,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:24 GMT
+      - Thu, 23 Aug 2018 10:34:07 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3811,7 +3811,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2203.5}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:24 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:07 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=10000&pw=1&scenario=4
@@ -3831,7 +3831,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:24 GMT
+      - Thu, 23 Aug 2018 10:34:07 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3848,7 +3848,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":14380.5}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:24 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:07 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=10001&pw=1&scenario=4
@@ -3868,7 +3868,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:24 GMT
+      - Thu, 23 Aug 2018 10:34:07 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3885,7 +3885,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":14380.5}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:24 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:07 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=0&pw=1&scenario=4
@@ -3905,7 +3905,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:24 GMT
+      - Thu, 23 Aug 2018 10:34:08 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3922,7 +3922,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1632.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:24 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:08 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=50&pw=1&scenario=4
@@ -3942,7 +3942,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:25 GMT
+      - Thu, 23 Aug 2018 10:34:08 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3959,7 +3959,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1632.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:25 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:08 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=51&pw=1&scenario=4
@@ -3979,7 +3979,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:25 GMT
+      - Thu, 23 Aug 2018 10:34:08 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -3996,7 +3996,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1632.81}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:25 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:08 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=100&pw=1&scenario=4
@@ -4016,7 +4016,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:25 GMT
+      - Thu, 23 Aug 2018 10:34:08 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4033,7 +4033,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1672.5}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:25 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:08 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=10000&pw=1&scenario=4
@@ -4053,7 +4053,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:25 GMT
+      - Thu, 23 Aug 2018 10:34:08 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4070,7 +4070,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":9691.5}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:25 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:08 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=10001&pw=1&scenario=4
@@ -4090,7 +4090,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:25 GMT
+      - Thu, 23 Aug 2018 10:34:08 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4107,7 +4107,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":9691.5}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:25 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:08 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=0&pw=1&scenario=4
@@ -4127,7 +4127,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:25 GMT
+      - Thu, 23 Aug 2018 10:34:08 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4144,7 +4144,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1632.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:25 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:08 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=50&pw=1&scenario=4
@@ -4164,7 +4164,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:25 GMT
+      - Thu, 23 Aug 2018 10:34:09 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4181,7 +4181,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1632.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:25 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:09 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=51&pw=1&scenario=4
@@ -4201,7 +4201,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:26 GMT
+      - Thu, 23 Aug 2018 10:34:09 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4218,7 +4218,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1632.98}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:26 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:09 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=100&pw=1&scenario=4
@@ -4238,7 +4238,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:26 GMT
+      - Thu, 23 Aug 2018 10:34:09 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4255,7 +4255,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1681.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:26 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:09 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=10000&pw=1&scenario=4
@@ -4275,7 +4275,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:26 GMT
+      - Thu, 23 Aug 2018 10:34:09 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4292,7 +4292,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":11383.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:26 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:09 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=10001&pw=1&scenario=4
@@ -4312,7 +4312,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:26 GMT
+      - Thu, 23 Aug 2018 10:34:09 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4329,7 +4329,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":11383.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:26 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:09 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=0&scenario=4
@@ -4349,7 +4349,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:26 GMT
+      - Thu, 23 Aug 2018 10:34:09 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4366,7 +4366,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2856.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:26 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:09 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=10&scenario=4
@@ -4386,7 +4386,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:26 GMT
+      - Thu, 23 Aug 2018 10:34:09 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4403,7 +4403,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2856.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:26 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:09 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=11&scenario=4
@@ -4423,7 +4423,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:26 GMT
+      - Thu, 23 Aug 2018 10:34:10 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4440,7 +4440,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2862.53}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:26 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:10 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=100&scenario=4
@@ -4460,7 +4460,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:27 GMT
+      - Thu, 23 Aug 2018 10:34:10 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4477,7 +4477,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":3443.7}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:27 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:10 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1000&scenario=4
@@ -4497,7 +4497,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:27 GMT
+      - Thu, 23 Aug 2018 10:34:10 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4514,7 +4514,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":9320.7}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:27 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:10 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=0&scenario=4
@@ -4534,7 +4534,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:27 GMT
+      - Thu, 23 Aug 2018 10:34:10 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4551,7 +4551,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2142.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:27 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:10 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=10&scenario=4
@@ -4571,7 +4571,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:27 GMT
+      - Thu, 23 Aug 2018 10:34:10 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4588,7 +4588,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2142.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:27 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:10 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=11&scenario=4
@@ -4608,7 +4608,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:27 GMT
+      - Thu, 23 Aug 2018 10:34:10 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4625,7 +4625,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2146.9}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:27 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:10 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=100&scenario=4
@@ -4645,7 +4645,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:27 GMT
+      - Thu, 23 Aug 2018 10:34:10 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4662,7 +4662,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2583.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:27 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:10 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1000&scenario=4
@@ -4682,7 +4682,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:28 GMT
+      - Thu, 23 Aug 2018 10:34:11 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4699,7 +4699,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":6993.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:28 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:11 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=0&scenario=4
@@ -4719,7 +4719,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:28 GMT
+      - Thu, 23 Aug 2018 10:34:11 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4736,7 +4736,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1632.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:28 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:11 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=10&scenario=4
@@ -4756,7 +4756,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:28 GMT
+      - Thu, 23 Aug 2018 10:34:11 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4773,7 +4773,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1632.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:28 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:11 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=11&scenario=4
@@ -4793,7 +4793,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:28 GMT
+      - Thu, 23 Aug 2018 10:34:11 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4810,7 +4810,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1635.26}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:28 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:11 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=100&scenario=4
@@ -4830,7 +4830,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:28 GMT
+      - Thu, 23 Aug 2018 10:34:11 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4847,7 +4847,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1925.4}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:28 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:11 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1000&scenario=4
@@ -4867,7 +4867,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:28 GMT
+      - Thu, 23 Aug 2018 10:34:11 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4884,7 +4884,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":4859.4}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:28 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:11 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=0&scenario=4
@@ -4904,7 +4904,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:28 GMT
+      - Thu, 23 Aug 2018 10:34:11 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4921,7 +4921,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1632.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:28 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:11 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=10&scenario=4
@@ -4941,7 +4941,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:29 GMT
+      - Thu, 23 Aug 2018 10:34:12 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4958,7 +4958,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1632.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:29 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:12 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=11&scenario=4
@@ -4978,7 +4978,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:29 GMT
+      - Thu, 23 Aug 2018 10:34:12 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -4995,7 +4995,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1636.9}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:29 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:12 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=100&scenario=4
@@ -5015,7 +5015,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:29 GMT
+      - Thu, 23 Aug 2018 10:34:12 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5032,7 +5032,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2073.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:29 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:12 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1000&scenario=4
@@ -5052,7 +5052,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:29 GMT
+      - Thu, 23 Aug 2018 10:34:12 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5069,7 +5069,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":6483.0}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:29 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:12 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=2&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5089,7 +5089,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:29 GMT
+      - Thu, 23 Aug 2018 10:34:12 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5106,7 +5106,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1958.4}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:29 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:12 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=3&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5126,7 +5126,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:29 GMT
+      - Thu, 23 Aug 2018 10:34:12 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5143,7 +5143,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2284.8}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:29 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:12 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=5&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5163,7 +5163,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:30 GMT
+      - Thu, 23 Aug 2018 10:34:13 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5180,7 +5180,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2937.6}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:30 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:13 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=10&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5200,7 +5200,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:30 GMT
+      - Thu, 23 Aug 2018 10:34:13 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5217,7 +5217,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":4569.6}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:30 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:13 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=100&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5237,7 +5237,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:30 GMT
+      - Thu, 23 Aug 2018 10:34:13 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5254,7 +5254,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":33945.6}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:30 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:13 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=10000&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5274,7 +5274,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:30 GMT
+      - Thu, 23 Aug 2018 10:34:13 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5291,7 +5291,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":3265305.6}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:30 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:13 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=2&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5311,7 +5311,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:30 GMT
+      - Thu, 23 Aug 2018 10:34:13 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5328,7 +5328,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1958.4}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:30 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:13 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=3&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5348,7 +5348,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:31 GMT
+      - Thu, 23 Aug 2018 10:34:13 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5365,7 +5365,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2284.8}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:31 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:13 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=5&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5385,7 +5385,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:31 GMT
+      - Thu, 23 Aug 2018 10:34:14 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5402,7 +5402,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":2937.6}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:31 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:14 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=10&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5422,7 +5422,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:31 GMT
+      - Thu, 23 Aug 2018 10:34:14 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5439,7 +5439,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":4569.6}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:31 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:14 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=100&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5459,7 +5459,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:31 GMT
+      - Thu, 23 Aug 2018 10:34:14 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5476,7 +5476,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":33945.6}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:31 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:14 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=10000&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5496,7 +5496,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:31 GMT
+      - Thu, 23 Aug 2018 10:34:14 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5513,7 +5513,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":3265305.6}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:31 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:14 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2018-01-01&type=LGFS
@@ -5533,7 +5533,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:32 GMT
+      - Thu, 23 Aug 2018 10:34:15 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5551,7 +5551,7 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":4,"start_date":"2017-12-01","end_date":null,"type":"LGFS","description":"LGFS
         Fee Scheme 2017-12"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:32 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:15 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=80&scenario=4
@@ -5571,7 +5571,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:32 GMT
+      - Thu, 23 Aug 2018 10:34:15 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5588,7 +5588,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1467.58}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:32 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:15 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=2&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=80&scenario=4
@@ -5608,7 +5608,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:32 GMT
+      - Thu, 23 Aug 2018 10:34:15 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5625,7 +5625,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1467.58}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:32 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:15 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=3&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=80&scenario=4
@@ -5645,7 +5645,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:33 GMT
+      - Thu, 23 Aug 2018 10:34:15 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5662,7 +5662,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1720.12}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:33 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:15 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=200&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=80&scenario=4
@@ -5682,7 +5682,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:33 GMT
+      - Thu, 23 Aug 2018 10:34:16 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5699,7 +5699,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":90159.18}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:33 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:16 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=201&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=80&scenario=4
@@ -5719,7 +5719,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:33 GMT
+      - Thu, 23 Aug 2018 10:34:16 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5736,7 +5736,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":90159.18}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:33 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:16 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=2&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=0&scenario=4
@@ -5756,7 +5756,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:34 GMT
+      - Thu, 23 Aug 2018 10:34:16 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5773,7 +5773,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1467.58}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:34 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:16 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=2&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=81&scenario=4
@@ -5793,7 +5793,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:34 GMT
+      - Thu, 23 Aug 2018 10:34:17 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5810,7 +5810,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1484.16}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:34 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:17 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=3&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=0&scenario=4
@@ -5830,7 +5830,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:34 GMT
+      - Thu, 23 Aug 2018 10:34:17 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5847,7 +5847,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1720.12}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:34 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:17 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=3&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&scenario=4
@@ -5867,7 +5867,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:35 GMT
+      - Thu, 23 Aug 2018 10:34:17 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5884,7 +5884,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1720.12}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:35 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:17 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=3&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=95&scenario=4
@@ -5904,7 +5904,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:35 GMT
+      - Thu, 23 Aug 2018 10:34:17 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5921,7 +5921,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1720.12}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:35 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:17 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=3&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=96&scenario=4
@@ -5941,7 +5941,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:35 GMT
+      - Thu, 23 Aug 2018 10:34:18 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5958,7 +5958,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1732.86}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:35 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:18 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=0&scenario=4
@@ -5978,7 +5978,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:35 GMT
+      - Thu, 23 Aug 2018 10:34:18 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -5995,7 +5995,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1097.66}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:35 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:18 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=70&scenario=4
@@ -6015,7 +6015,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:36 GMT
+      - Thu, 23 Aug 2018 10:34:18 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -6032,7 +6032,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1097.66}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:36 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:18 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=71&scenario=4
@@ -6052,7 +6052,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:36 GMT
+      - Thu, 23 Aug 2018 10:34:18 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -6069,7 +6069,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1110.47}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:36 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:18 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=2&offence_class=A&ppe=80&scenario=4
@@ -6089,7 +6089,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:36 GMT
+      - Thu, 23 Aug 2018 10:34:19 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -6106,7 +6106,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1761.1}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:36 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:19 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=3&offence_class=A&ppe=80&scenario=4
@@ -6126,7 +6126,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:36 GMT
+      - Thu, 23 Aug 2018 10:34:19 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -6143,7 +6143,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1761.1}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:36 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:19 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=4&offence_class=A&ppe=80&scenario=4
@@ -6163,7 +6163,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:37 GMT
+      - Thu, 23 Aug 2018 10:34:19 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -6180,7 +6180,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1761.1}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:37 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:19 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=5&offence_class=A&ppe=80&scenario=4
@@ -6200,7 +6200,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:37 GMT
+      - Thu, 23 Aug 2018 10:34:20 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -6217,7 +6217,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1907.85}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:37 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:20 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=10&offence_class=A&ppe=80&scenario=4
@@ -6237,7 +6237,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:37 GMT
+      - Thu, 23 Aug 2018 10:34:20 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -6254,7 +6254,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1907.85}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:37 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:20 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/4/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=100&offence_class=A&ppe=80&scenario=4
@@ -6274,7 +6274,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:37 GMT
+      - Thu, 23 Aug 2018 10:34:20 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -6291,5 +6291,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1907.85}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:37 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:20 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr/modifier_types_spec.yml
+++ b/spec/vcr/modifier_types_spec.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:39 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
         Fee Scheme 9"}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:39 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/modifier-types/
@@ -57,7 +57,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:39 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -80,7 +80,7 @@ http_interactions:
         months between trials","unit":"MONTH"},{"id":6,"name":"THIRD_CRACKED","description":"Third
         in which a trial cracked","unit":"THIRD"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:39 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/modifier-types/1/
@@ -100,7 +100,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:39 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -117,7 +117,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"id":1,"name":"NUMBER_OF_CASES","description":"Number of cases","unit":"CASE"}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:39 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/modifier-types/?scenario=1
@@ -137,7 +137,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:39 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -158,7 +158,7 @@ http_interactions:
         length","unit":"DAY"},{"id":4,"name":"PAGES_OF_PROSECUTING_EVIDENCE","description":"Pages
         of prosecuting evidence","unit":"PPE"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:39 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/modifier-types/?advocate_type=QC
@@ -178,7 +178,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:39 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -201,7 +201,7 @@ http_interactions:
         months between trials","unit":"MONTH"},{"id":6,"name":"THIRD_CRACKED","description":"Third
         in which a trial cracked","unit":"THIRD"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:39 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/modifier-types/?offence_class=A
@@ -221,7 +221,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:39 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -244,7 +244,7 @@ http_interactions:
         months between trials","unit":"MONTH"},{"id":6,"name":"THIRD_CRACKED","description":"Third
         in which a trial cracked","unit":"THIRD"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:39 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/modifier-types/?fee_type_code=AGFS_FEE
@@ -264,7 +264,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:39 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -286,7 +286,7 @@ http_interactions:
         months between trials","unit":"MONTH"},{"id":6,"name":"THIRD_CRACKED","description":"Third
         in which a trial cracked","unit":"THIRD"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:39 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/modifier-types/1001/
@@ -306,7 +306,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:40 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -323,7 +323,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:40 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/modifier-types/?fee_type_code=INVALID_CODE
@@ -343,7 +343,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:40 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -360,7 +360,7 @@ http_interactions:
       encoding: UTF-8
       string: '["''INVALID_CODE'' is not a valid `fee_type_code`"]'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:40 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/modifier-types/?fee_type_code=AGFS_APPEAL_CON&scenario=5
@@ -380,7 +380,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:40 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -399,5 +399,5 @@ http_interactions:
         of cases","unit":"CASE"},{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:40 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr/offence_classes_spec.yml
+++ b/spec/vcr/offence_classes_spec.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:40 GMT
+      - Thu, 23 Aug 2018 10:34:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
         Fee Scheme 9"}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:40 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:21 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/offence-classes/
@@ -57,7 +57,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:40 GMT
+      - Thu, 23 Aug 2018 10:34:22 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -84,7 +84,7 @@ http_interactions:
         sexual offences"},{"id":"K","name":"K","description":"Other offences of dishonesty
         (high value)"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:40 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:22 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/offence-classes/A/
@@ -104,7 +104,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:40 GMT
+      - Thu, 23 Aug 2018 10:34:22 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -121,7 +121,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"id":"A","name":"A","description":"Homicide and related grave offences"}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:40 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:22 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/offence-classes/INVALID/
@@ -141,7 +141,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:40 GMT
+      - Thu, 23 Aug 2018 10:34:22 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -158,5 +158,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:40 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:22 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr/prices_spec.yml
+++ b/spec/vcr/prices_spec.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:40 GMT
+      - Thu, 23 Aug 2018 10:34:22 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
         Fee Scheme 9"}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:40 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:22 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/prices/
@@ -57,7 +57,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:40 GMT
+      - Thu, 23 Aug 2018 10:34:22 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -72,7 +72,7 @@ http_interactions:
       - '46816'
     body:
       encoding: UTF-8
-      string: '{"count":3270,"next":"http://localhost:8000/api/v1/fee-schemes/1/prices/?page=2","previous":null,"results":[{"id":1,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+      string: '{"count":2890,"next":"http://localhost:8000/api/v1/fee-schemes/1/prices/?page=2","previous":null,"results":[{"id":1,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
@@ -178,7 +178,7 @@ http_interactions:
         months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
         months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:40 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:22 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/prices/1/
@@ -198,7 +198,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:40 GMT
+      - Thu, 23 Aug 2018 10:34:22 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -217,7 +217,7 @@ http_interactions:
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:40 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:22 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/prices/?scenario=5
@@ -237,7 +237,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:40 GMT
+      - Thu, 23 Aug 2018 10:34:22 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -249,10 +249,10 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '45483'
+      - '41779'
     body:
       encoding: UTF-8
-      string: '{"count":148,"next":"http://localhost:8000/api/v1/fee-schemes/1/prices/?page=2&scenario=5","previous":null,"results":[{"id":1815,"scenario":5,"advocate_type":"QC","fee_type":5,"offence_class":null,"scheme":1,"unit":"HALFDAY","fee_per_unit":"260.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":60,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+      string: '{"count":128,"next":"http://localhost:8000/api/v1/fee-schemes/1/prices/?page=2&scenario=5","previous":null,"results":[{"id":1815,"scenario":5,"advocate_type":"QC","fee_type":5,"offence_class":null,"scheme":1,"unit":"HALFDAY","fee_per_unit":"260.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":60,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":1825,"scenario":5,"advocate_type":"LEDJR","fee_type":5,"offence_class":null,"scheme":1,"unit":"HALFDAY","fee_per_unit":"130.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":60,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":1830,"scenario":5,"advocate_type":"LEADJR","fee_type":5,"offence_class":null,"scheme":1,"unit":"HALFDAY","fee_per_unit":"195.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":60,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":1840,"scenario":5,"advocate_type":"JRALONE","fee_type":5,"offence_class":null,"scheme":1,"unit":"HALFDAY","fee_per_unit":"130.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":60,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
@@ -280,27 +280,11 @@ http_interactions:
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2064,"scenario":5,"advocate_type":"JRALONE","fee_type":8,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"130.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2076,"scenario":5,"advocate_type":"QC","fee_type":9,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"216.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2085,"scenario":5,"advocate_type":"LEDJR","fee_type":9,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"108.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2097,"scenario":5,"advocate_type":"LEADJR","fee_type":9,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2108,"scenario":5,"advocate_type":"JRALONE","fee_type":9,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"108.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2117,"scenario":5,"advocate_type":"QC","fee_type":15,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"175.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[],"strict_range":false},{"id":2127,"scenario":5,"advocate_type":"LEDJR","fee_type":15,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"100.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[],"strict_range":false},{"id":2139,"scenario":5,"advocate_type":"LEADJR","fee_type":15,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"125.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[],"strict_range":false},{"id":2155,"scenario":5,"advocate_type":"JRALONE","fee_type":15,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"100.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[],"strict_range":false},{"id":2164,"scenario":5,"advocate_type":"QC","fee_type":12,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"260.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":60,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2177,"scenario":5,"advocate_type":"LEDJR","fee_type":12,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"130.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":60,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2180,"scenario":5,"advocate_type":"LEADJR","fee_type":12,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"195.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":60,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2191,"scenario":5,"advocate_type":"JRALONE","fee_type":12,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"130.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":60,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2206,"scenario":5,"advocate_type":"QC","fee_type":13,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"74.00000","fixed_fee":"0.00000","limit_from":7,"limit_to":8,"modifiers":[{"limit_from":21,"limit_to":25,"fixed_percent":"0.00","percent_per_unit":"0.00","modifier_type":{"id":3,"name":"TRIAL_LENGTH","description":"Trial
         length","unit":"DAY"},"required":true,"priority":0,"strict_range":false}],"strict_range":false},{"id":2216,"scenario":5,"advocate_type":"LEDJR","fee_type":13,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"39.00000","fixed_fee":"0.00000","limit_from":7,"limit_to":8,"modifiers":[{"limit_from":21,"limit_to":25,"fixed_percent":"0.00","percent_per_unit":"0.00","modifier_type":{"id":3,"name":"TRIAL_LENGTH","description":"Trial
         length","unit":"DAY"},"required":true,"priority":0,"strict_range":false}],"strict_range":false},{"id":2229,"scenario":5,"advocate_type":"LEADJR","fee_type":13,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"56.00000","fixed_fee":"0.00000","limit_from":7,"limit_to":8,"modifiers":[{"limit_from":21,"limit_to":25,"fixed_percent":"0.00","percent_per_unit":"0.00","modifier_type":{"id":3,"name":"TRIAL_LENGTH","description":"Trial
         length","unit":"DAY"},"required":true,"priority":0,"strict_range":false}],"strict_range":false},{"id":2236,"scenario":5,"advocate_type":"JRALONE","fee_type":13,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"39.00000","fixed_fee":"0.00000","limit_from":7,"limit_to":8,"modifiers":[{"limit_from":21,"limit_to":25,"fixed_percent":"0.00","percent_per_unit":"0.00","modifier_type":{"id":3,"name":"TRIAL_LENGTH","description":"Trial
-        length","unit":"DAY"},"required":true,"priority":0,"strict_range":false}],"strict_range":false},{"id":2255,"scenario":5,"advocate_type":"QC","fee_type":14,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"300.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":60,"modifiers":[],"strict_range":false},{"id":2266,"scenario":5,"advocate_type":"LEDJR","fee_type":14,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"150.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":60,"modifiers":[],"strict_range":false},{"id":2268,"scenario":5,"advocate_type":"LEADJR","fee_type":14,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"225.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":60,"modifiers":[],"strict_range":false},{"id":2278,"scenario":5,"advocate_type":"JRALONE","fee_type":14,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"150.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":60,"modifiers":[],"strict_range":false},{"id":2299,"scenario":5,"advocate_type":"QC","fee_type":16,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"324.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        length","unit":"DAY"},"required":true,"priority":0,"strict_range":false}],"strict_range":false},{"id":2299,"scenario":5,"advocate_type":"QC","fee_type":16,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"324.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2307,"scenario":5,"advocate_type":"LEDJR","fee_type":16,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"173.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2318,"scenario":5,"advocate_type":"LEADJR","fee_type":16,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"238.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2324,"scenario":5,"advocate_type":"JRALONE","fee_type":16,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"173.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
@@ -324,15 +308,7 @@ http_interactions:
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2528,"scenario":5,"advocate_type":"LEDJR","fee_type":30,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"130.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2539,"scenario":5,"advocate_type":"LEADJR","fee_type":30,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"195.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2552,"scenario":5,"advocate_type":"JRALONE","fee_type":30,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"130.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2556,"scenario":5,"advocate_type":"QC","fee_type":20,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"0.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2574,"scenario":5,"advocate_type":"LEDJR","fee_type":20,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"108.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[],"strict_range":false},{"id":2576,"scenario":5,"advocate_type":"LEADJR","fee_type":20,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"0.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2592,"scenario":5,"advocate_type":"JRALONE","fee_type":20,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"108.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[],"strict_range":false},{"id":2601,"scenario":5,"advocate_type":"QC","fee_type":26,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"74.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2609,"scenario":5,"advocate_type":"LEDJR","fee_type":26,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"39.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2619,"scenario":5,"advocate_type":"LEADJR","fee_type":26,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"56.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2636,"scenario":5,"advocate_type":"JRALONE","fee_type":26,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"39.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2642,"scenario":5,"advocate_type":"QC","fee_type":25,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"74.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2662,"scenario":5,"advocate_type":"LEDJR","fee_type":25,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"39.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2672,"scenario":5,"advocate_type":"LEADJR","fee_type":25,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"56.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2684,"scenario":5,"advocate_type":"JRALONE","fee_type":25,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"39.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2694,"scenario":5,"advocate_type":"QC","fee_type":22,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"216.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2704,"scenario":5,"advocate_type":"LEDJR","fee_type":22,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"108.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2717,"scenario":5,"advocate_type":"LEADJR","fee_type":22,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2722,"scenario":5,"advocate_type":"JRALONE","fee_type":22,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"108.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2738,"scenario":5,"advocate_type":"QC","fee_type":21,"offence_class":null,"scheme":1,"unit":"CASE","fee_per_unit":"26.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2556,"scenario":5,"advocate_type":"QC","fee_type":20,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"0.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2574,"scenario":5,"advocate_type":"LEDJR","fee_type":20,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"108.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[],"strict_range":false},{"id":2576,"scenario":5,"advocate_type":"LEADJR","fee_type":20,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"0.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2592,"scenario":5,"advocate_type":"JRALONE","fee_type":20,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"108.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[],"strict_range":false},{"id":2601,"scenario":5,"advocate_type":"QC","fee_type":26,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"74.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2609,"scenario":5,"advocate_type":"LEDJR","fee_type":26,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"39.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2619,"scenario":5,"advocate_type":"LEADJR","fee_type":26,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"56.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2636,"scenario":5,"advocate_type":"JRALONE","fee_type":26,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"39.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2642,"scenario":5,"advocate_type":"QC","fee_type":25,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"74.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2662,"scenario":5,"advocate_type":"LEDJR","fee_type":25,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"39.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2672,"scenario":5,"advocate_type":"LEADJR","fee_type":25,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"56.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2684,"scenario":5,"advocate_type":"JRALONE","fee_type":25,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"39.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2738,"scenario":5,"advocate_type":"QC","fee_type":21,"offence_class":null,"scheme":1,"unit":"CASE","fee_per_unit":"26.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2741,"scenario":5,"advocate_type":"LEDJR","fee_type":21,"offence_class":null,"scheme":1,"unit":"CASE","fee_per_unit":"26.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2761,"scenario":5,"advocate_type":"LEADJR","fee_type":21,"offence_class":null,"scheme":1,"unit":"CASE","fee_per_unit":"26.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2772,"scenario":5,"advocate_type":"JRALONE","fee_type":21,"offence_class":null,"scheme":1,"unit":"CASE","fee_per_unit":"26.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
@@ -348,9 +324,17 @@ http_interactions:
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2914,"scenario":5,"advocate_type":"LEDJR","fee_type":4,"offence_class":null,"scheme":1,"unit":"CASE","fee_per_unit":"87.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":null,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2920,"scenario":5,"advocate_type":"LEADJR","fee_type":4,"offence_class":null,"scheme":1,"unit":"CASE","fee_per_unit":"130.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":null,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2927,"scenario":5,"advocate_type":"JRALONE","fee_type":4,"offence_class":null,"scheme":1,"unit":"CASE","fee_per_unit":"87.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":null,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2936,"scenario":5,"advocate_type":"QC","fee_type":29,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"74.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2950,"scenario":5,"advocate_type":"LEDJR","fee_type":29,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"39.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2959,"scenario":5,"advocate_type":"LEADJR","fee_type":29,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"56.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2969,"scenario":5,"advocate_type":"JRALONE","fee_type":29,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"39.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2983,"scenario":5,"advocate_type":"QC","fee_type":36,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"74.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":2992,"scenario":5,"advocate_type":"LEDJR","fee_type":36,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"39.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":3004,"scenario":5,"advocate_type":"LEADJR","fee_type":36,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"56.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":3007,"scenario":5,"advocate_type":"JRALONE","fee_type":36,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"39.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":3071,"scenario":5,"advocate_type":"QC","fee_type":31,"offence_class":null,"scheme":1,"unit":"HALFDAY","fee_per_unit":"260.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":60,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":3084,"scenario":5,"advocate_type":"LEDJR","fee_type":31,"offence_class":null,"scheme":1,"unit":"HALFDAY","fee_per_unit":"130.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":60,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":3092,"scenario":5,"advocate_type":"LEADJR","fee_type":31,"offence_class":null,"scheme":1,"unit":"HALFDAY","fee_per_unit":"195.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":60,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":3102,"scenario":5,"advocate_type":"JRALONE","fee_type":31,"offence_class":null,"scheme":1,"unit":"HALFDAY","fee_per_unit":"130.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":60,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":3114,"scenario":5,"advocate_type":"QC","fee_type":32,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"497.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":3121,"scenario":5,"advocate_type":"LEDJR","fee_type":32,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"238.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":3141,"scenario":5,"advocate_type":"LEADJR","fee_type":32,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"346.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":3142,"scenario":5,"advocate_type":"JRALONE","fee_type":32,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"238.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":3162,"scenario":5,"advocate_type":"QC","fee_type":33,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"74.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":3167,"scenario":5,"advocate_type":"LEDJR","fee_type":33,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"39.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":3176,"scenario":5,"advocate_type":"LEADJR","fee_type":33,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"56.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":3189,"scenario":5,"advocate_type":"JRALONE","fee_type":33,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"39.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:40 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:22 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/prices/?advocate_type=QC
@@ -370,7 +354,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:41 GMT
+      - Thu, 23 Aug 2018 10:34:22 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -385,7 +369,7 @@ http_interactions:
       - '54443'
     body:
       encoding: UTF-8
-      string: '{"count":817,"next":"http://localhost:8000/api/v1/fee-schemes/1/prices/?advocate_type=QC&page=2","previous":null,"results":[{"id":1,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+      string: '{"count":722,"next":"http://localhost:8000/api/v1/fee-schemes/1/prices/?advocate_type=QC&page=2","previous":null,"results":[{"id":1,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
@@ -523,7 +507,7 @@ http_interactions:
         months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":1,"fixed_percent":"0.00","percent_per_unit":"0.00","modifier_type":{"id":6,"name":"THIRD_CRACKED","description":"Third
         in which a trial cracked","unit":"THIRD"},"required":true,"priority":0,"strict_range":true}],"strict_range":false}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:41 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:22 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/prices/?offence_class=A
@@ -543,7 +527,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:41 GMT
+      - Thu, 23 Aug 2018 10:34:23 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -558,7 +542,7 @@ http_interactions:
       - '69237'
     body:
       encoding: UTF-8
-      string: '{"count":1948,"next":"http://localhost:8000/api/v1/fee-schemes/1/prices/?offence_class=A&page=2","previous":null,"results":[{"id":1,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+      string: '{"count":1568,"next":"http://localhost:8000/api/v1/fee-schemes/1/prices/?offence_class=A&page=2","previous":null,"results":[{"id":1,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
@@ -756,7 +740,7 @@ http_interactions:
         months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":1,"fixed_percent":"0.00","percent_per_unit":"0.00","modifier_type":{"id":6,"name":"THIRD_CRACKED","description":"Third
         in which a trial cracked","unit":"THIRD"},"required":true,"priority":0,"strict_range":true}],"strict_range":false}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:41 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:23 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/prices/?fee_type_code=AGFS_FEE
@@ -776,7 +760,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:41 GMT
+      - Thu, 23 Aug 2018 10:34:23 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -897,7 +881,7 @@ http_interactions:
         months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
         months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:41 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:23 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/prices/-1/
@@ -917,7 +901,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:41 GMT
+      - Thu, 23 Aug 2018 10:34:23 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -934,7 +918,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:41 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:23 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/prices/?page=2
@@ -954,7 +938,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:42 GMT
+      - Thu, 23 Aug 2018 10:34:23 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -969,7 +953,7 @@ http_interactions:
       - '45389'
     body:
       encoding: UTF-8
-      string: '{"count":3270,"next":"http://localhost:8000/api/v1/fee-schemes/1/prices/?page=3","previous":"http://localhost:8000/api/v1/fee-schemes/1/prices/","results":[{"id":101,"scenario":4,"advocate_type":"LEADJR","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"331.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":102,"scenario":11,"advocate_type":"LEADJR","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"331.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":103,"scenario":4,"advocate_type":"LEADJR","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"356.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":104,"scenario":11,"advocate_type":"LEADJR","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"356.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":105,"scenario":4,"advocate_type":"LEADJR","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1476.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+      string: '{"count":2890,"next":"http://localhost:8000/api/v1/fee-schemes/1/prices/?page=3","previous":"http://localhost:8000/api/v1/fee-schemes/1/prices/","results":[{"id":101,"scenario":4,"advocate_type":"LEADJR","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"331.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":102,"scenario":11,"advocate_type":"LEADJR","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"331.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":103,"scenario":4,"advocate_type":"LEADJR","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"356.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":104,"scenario":11,"advocate_type":"LEADJR","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"356.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":105,"scenario":4,"advocate_type":"LEADJR","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1476.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":106,"scenario":11,"advocate_type":"LEADJR","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1476.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
@@ -1067,7 +1051,7 @@ http_interactions:
         months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
         months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":197,"scenario":4,"advocate_type":"LEDJR","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"221.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":198,"scenario":11,"advocate_type":"LEDJR","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"221.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":199,"scenario":4,"advocate_type":"LEDJR","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"237.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":200,"scenario":11,"advocate_type":"LEDJR","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"237.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:42 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:23 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/prices/?fee_type_code=AGFS_APPEAL_CON&scenario=5
@@ -1087,7 +1071,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:42 GMT
+      - Thu, 23 Aug 2018 10:34:23 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -1112,5 +1096,5 @@ http_interactions:
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:42 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:23 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr/scenarios_spec.yml
+++ b/spec/vcr/scenarios_spec.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:42 GMT
+      - Thu, 23 Aug 2018 10:34:23 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
         Fee Scheme 9"}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:42 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:23 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/scenarios/
@@ -57,7 +57,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:42 GMT
+      - Thu, 23 Aug 2018 10:34:23 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -79,7 +79,7 @@ http_interactions:
         of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":12,"name":"Elected
         case not proceeded","code":"AS000014"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:42 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:23 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/scenarios/1/
@@ -99,7 +99,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:42 GMT
+      - Thu, 23 Aug 2018 10:34:23 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -116,7 +116,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"id":1,"name":"Discontinuance","code":"AS000001"}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:42 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:23 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/scenarios/1001/
@@ -136,7 +136,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:42 GMT
+      - Thu, 23 Aug 2018 10:34:23 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -153,5 +153,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:42 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:23 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr/units_spec.yml
+++ b/spec/vcr/units_spec.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:42 GMT
+      - Thu, 23 Aug 2018 10:34:23 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
         Fee Scheme 9"}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:42 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:23 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/units/
@@ -57,7 +57,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:42 GMT
+      - Thu, 23 Aug 2018 10:34:23 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -76,7 +76,7 @@ http_interactions:
         Days"},{"id":"HALFDAY","name":"Half Days"},{"id":"HOUR","name":"Hours"},{"id":"PPE","name":"Pages
         of Prosecuting Evidence"},{"id":"PW","name":"Prosecution Witnesses"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:42 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:23 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/units/DAY/
@@ -96,7 +96,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:42 GMT
+      - Thu, 23 Aug 2018 10:34:23 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -113,7 +113,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"id":"DAY","name":"Whole Days"}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:42 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:23 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/units/?scenario=1
@@ -133,7 +133,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:42 GMT
+      - Thu, 23 Aug 2018 10:34:23 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -152,7 +152,7 @@ http_interactions:
         Days"},{"id":"HALFDAY","name":"Half Days"},{"id":"HOUR","name":"Hours"},{"id":"PPE","name":"Pages
         of Prosecuting Evidence"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:42 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:23 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/units/?advocate_type=QC
@@ -172,7 +172,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:42 GMT
+      - Thu, 23 Aug 2018 10:34:23 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -191,7 +191,7 @@ http_interactions:
         Days"},{"id":"HALFDAY","name":"Half Days"},{"id":"HOUR","name":"Hours"},{"id":"PPE","name":"Pages
         of Prosecuting Evidence"},{"id":"PW","name":"Prosecution Witnesses"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:42 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:23 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/units/?offence_class=A
@@ -211,7 +211,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:42 GMT
+      - Thu, 23 Aug 2018 10:34:23 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -230,7 +230,7 @@ http_interactions:
         Days"},{"id":"HALFDAY","name":"Half Days"},{"id":"HOUR","name":"Hours"},{"id":"PPE","name":"Pages
         of Prosecuting Evidence"},{"id":"PW","name":"Prosecution Witnesses"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:42 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:23 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/units/?fee_type_code=AGFS_FEE
@@ -250,7 +250,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:42 GMT
+      - Thu, 23 Aug 2018 10:34:23 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -269,7 +269,7 @@ http_interactions:
         Days"},{"id":"PPE","name":"Pages of Prosecuting Evidence"},{"id":"PW","name":"Prosecution
         Witnesses"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:42 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:23 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/units/1001/
@@ -289,7 +289,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:42 GMT
+      - Thu, 23 Aug 2018 10:34:23 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -306,7 +306,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:42 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:23 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/units/?fee_type_code=INVALID_FEE_TYPE_CODE&scenario=5
@@ -326,7 +326,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:42 GMT
+      - Thu, 23 Aug 2018 10:34:23 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -343,7 +343,7 @@ http_interactions:
       encoding: UTF-8
       string: '["''INVALID_FEE_TYPE_CODE'' is not a valid `fee_type_code`"]'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:42 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:23 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/1/units/?offence_class=E&scenario=5
@@ -363,7 +363,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Jul 2018 11:15:42 GMT
+      - Thu, 23 Aug 2018 10:34:23 GMT
       Server:
       - WSGIServer/0.2 CPython/3.6.5
       Content-Type:
@@ -381,5 +381,5 @@ http_interactions:
       string: '{"count":4,"next":null,"previous":null,"results":[{"id":"CASE","name":"Case"},{"id":"DAY","name":"Whole
         Days"},{"id":"HALFDAY","name":"Half Days"},{"id":"HOUR","name":"Hours"}]}'
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 11:15:42 GMT
+  recorded_at: Thu, 23 Aug 2018 10:34:23 GMT
 recorded_with: VCR 4.0.0


### PR DESCRIPTION
#### What
point client at production fee calculator API

#### Why
The production host for the calculator API
has been released and is in use on CCCD.

Default gems config to point to this as
the stable source of truth for fee calculation.
