### PR TITLE
Increment the version to 0.2.0 and amend release date

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ Bug reports and pull requests are welcome on GitHub at [ministryofjustice/laa-fe
 
 2. Run `bin/ruby_version_test` to test against ruby versions (2.4+ supported at present)
 
-3. Update the version in `lib/laa/fee_calculator/version` using [semantic versioning](https://guides.rubygems.org/patterns/#semantic-versioning).
+3. Update the VERSION in `lib/laa/fee_calculator/version` using [semantic versioning](https://guides.rubygems.org/patterns/#semantic-versioning).
 
-4. Update the `gemspec` file to give version a release date. (e.g. `spec.date = '2018-06-29'`)
+4. Update the VERSION_RELEASED in `lib/laa/fee_calculator/version` to the date you intend to publish/release the version.
 
 5. PR the change, code-review, merge.
 

--- a/laa-fee-calculator-client.gemspec
+++ b/laa-fee-calculator-client.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.version       = LAA::FeeCalculator::VERSION
   spec.authors       = ['Joel Sugarman', 'Ministry of Justice']
   spec.email         = ['joel.sugarman@digital.justice.gov.uk', 'tools@digital.justice.gov.uk']
-  spec.date          = '2018-06-29'
+  spec.date          = LAA::FeeCalculator::VERSION_RELEASED
   spec.summary       = 'Ruby client for the Legal Aid Agency fee calculator API'
   spec.description   = "Ruby client for the Ministry of Justices LAA fee calculator API. A simple interface for transparent calling of the API endpoints to query data and return calculated fee amounts."
   spec.homepage      = 'https://github.com/ministryofjustice/laa-fee-calculator-client'

--- a/lib/laa/fee_calculator/version.rb
+++ b/lib/laa/fee_calculator/version.rb
@@ -2,7 +2,8 @@
 
 module LAA
   module FeeCalculator
-    VERSION = "0.1.4"
+    VERSION = "0.2.0"
+    VERSION_RELEASED = "2018-09-18"
     USER_AGENT = "laa-fee-calculator-client/#{VERSION}"
   end
 end


### PR DESCRIPTION
#### What
Increment the version to 0.2.0 and amend release date

#### Why
Previous version of 0.1.4 to be yanked as it does
not comply with semantic versioning (adding functionality
is considered a minor non-breaking change).

In addition previous versions have all be released with
the gemspec.date parameter set to original release date.
This date should reflect the version release date.