### PR TITLE
Allow Faraday to be updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ Add latest change log entries at top using template:
   -
 
 ```
+## Version 1.3.0
+
+### Modified
+  - update Faraday dependency
+
+### Added
+  - support for Ruby 3.0 and 3.1
+
+### Removed
+  - removed support for Ruby 2.6
+
 ## Version 1.2.0
 
 ### Modified

--- a/laa-fee-calculator-client.gemspec
+++ b/laa-fee-calculator-client.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6.0'
 
   spec.add_runtime_dependency 'addressable', '~> 2.3', '>= 2.3.7'
-  spec.add_runtime_dependency 'faraday', '>= 0.9.2', '< 1.4.0'
+  spec.add_runtime_dependency 'faraday', '~> 1.0'
 
   spec.add_development_dependency 'awesome_print'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/lib/laa/fee_calculator/version.rb
+++ b/lib/laa/fee_calculator/version.rb
@@ -2,8 +2,8 @@
 
 module LAA
   module FeeCalculator
-    VERSION = "1.2.0"
-    VERSION_RELEASED = "2021-02-01"
+    VERSION = "1.3.0"
+    VERSION_RELEASED = "2022-04-21"
     USER_AGENT = "laa-fee-calculator-client/#{VERSION}"
   end
 end


### PR DESCRIPTION
The version restriction on the Faraday gem was `'>= 0.9.2', '< 1.4.0'` and is now `'~> 1.0.0', meaning that it can be updated to the latest version 1.x (currently 1.10.0) but versions 0.x are now excluded.

According to the change log the most significant update of Faraday that this will allow is version 1.4. See https://github.com/lostisland/faraday/releases/tag/v1.4.0

Note that the latest version of Faraday is now 2.2.