### PR TITLE
Update for ruby 3

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -13,13 +13,9 @@ jobs:
     continue-on-error: ${{ matrix.accepted-failure }}
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1']
         accepted-failure: [false]
         include:
-          - ruby-version: '3.0'
-            accepted-failure: true
-          - ruby-version: '3.1'
-            accepted-failure: true
           - ruby-version: 'head'
             accepted-failure: true
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ laa-fee-calculator-client*/
 
 # Gemfile.lock since it enforces precision that does not exist in the gem command
 Gemfile.lock
+
+.ruby-version

--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "pry-byebug"
 require "laa/fee_calculator"
 
 # You can add fixtures and/or initialization code here to make experimenting

--- a/laa-fee-calculator-client.gemspec
+++ b/laa-fee-calculator-client.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'faraday', '>= 0.9.2', '< 1.4.0'
 
   spec.add_development_dependency 'awesome_print'
-  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rb-readline'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/spec/laa/fee_calculator/fee_scheme_spec.rb
+++ b/spec/laa/fee_calculator/fee_scheme_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe LAA::FeeCalculator::FeeScheme, :vcr do
 
   describe '#calculate' do
     subject(:calculate) do
-      fee_scheme.calculate(options)
+      fee_scheme.calculate(**options)
     end
 
     let(:options) do
@@ -50,7 +50,7 @@ RSpec.describe LAA::FeeCalculator::FeeScheme, :vcr do
     end
 
     it 'yields options to block' do
-      expect { |block| fee_scheme.calculate(options, &block) }.to yield_with_args(instance_of(Hash))
+      expect { |block| fee_scheme.calculate(**options, &block) }.to yield_with_args(instance_of(Hash))
     end
   end
 end

--- a/spec/laa/fee_calculator/integration/errors_spec.rb
+++ b/spec/laa/fee_calculator/integration/errors_spec.rb
@@ -78,13 +78,13 @@ RSpec.describe LAA::FeeCalculator, :vcr do
       end
 
       subject(:calculate) do
-        fee_scheme.calculate(options)
+        fee_scheme.calculate(**options)
       end
 
       context 'when not supplied with required params' do
         subject(:calculate) do
           fee_scheme.calculate(
-            options.reject { |k, _v| k.eql?(:fee_type_code) }
+            **options.reject { |k, _v| k.eql?(:fee_type_code) }
           )
         end
 
@@ -171,13 +171,12 @@ RSpec.describe LAA::FeeCalculator, :vcr do
       context 'when supplied with unneeded or invalid params' do
         subject(:calculate) do
           fee_scheme.calculate(
-            options.merge(
-              fixed: 2,
-              defendant: 2,
-              halfday: 2,
-              not_a_real_param: 'rubbish',
-              hour: 2
-            )
+            **options,
+            fixed: 2,
+            defendant: 2,
+            halfday: 2,
+            not_a_real_param: 'rubbish',
+            hour: 2
           )
         end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@
 
 require "laa/fee_calculator"
 require "bundler/setup"
-require 'pry-byebug'
 require 'awesome_print'
 require 'webmock/rspec'
 require 'vcr'

--- a/spec/support/helpers/regulations.rb
+++ b/spec/support/helpers/regulations.rb
@@ -17,7 +17,6 @@ module Helpers
       return hash unless options
 
       hash.select do |row|
-        # binding.pry unless row[:offence_class].eql?('A')
         options.map { |attr, val| row[attr].eql?(val) }.all?
       end
     end

--- a/spec/vcr/advocate_types_spec.yml
+++ b/spec/vcr/advocate_types_spec.yml
@@ -2,45 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:19:16 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '106'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Allow:
-      - GET, HEAD, OPTIONS
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
-        Fee Scheme 9"}'
-  recorded_at: Wed, 03 Feb 2021 16:19:16 GMT
-- request:
-    method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/advocate-types/
     body:
       encoding: US-ASCII
@@ -58,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:16 GMT
+      - Wed, 20 Apr 2022 11:54:05 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -66,11 +27,11 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -78,7 +39,7 @@ http_interactions:
       string: '{"count":4,"next":null,"previous":null,"results":[{"id":"JRALONE","name":"Junior
         alone"},{"id":"LEADJR","name":"Leading junior"},{"id":"LEDJR","name":"Led
         junior"},{"id":"QC","name":"QC"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:16 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:05 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/advocate-types/JRALONE/
@@ -98,17 +59,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:16 GMT
+      - Wed, 20 Apr 2022 11:54:06 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '38'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -116,7 +77,46 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"id":"JRALONE","name":"Junior alone"}'
-  recorded_at: Wed, 03 Feb 2021 16:19:16 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:06 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:54:06 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '106'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
+        Fee Scheme 9"}'
+  recorded_at: Wed, 20 Apr 2022 11:54:06 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/advocate-types/INVALID/
@@ -136,17 +136,17 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:16 GMT
+      - Wed, 20 Apr 2022 11:54:06 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '23'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -154,7 +154,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
-  recorded_at: Wed, 03 Feb 2021 16:19:16 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:06 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/
@@ -174,26 +174,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:16 GMT
+      - Wed, 20 Apr 2022 11:54:06 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '104'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
         Fee Scheme 2016-04"}'
-  recorded_at: Wed, 03 Feb 2021 16:19:16 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:06 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/advocate-types/
@@ -213,7 +213,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:16 GMT
+      - Wed, 20 Apr 2022 11:54:06 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -221,15 +221,15 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"count":0,"next":null,"previous":null,"results":[]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:16 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:06 GMT
 recorded_with: VCR 6.0.0

--- a/spec/vcr/client_spec.yml
+++ b/spec/vcr/client_spec.yml
@@ -19,17 +19,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:16 GMT
+      - Wed, 20 Apr 2022 11:54:05 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '607'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -42,5 +42,5 @@ http_interactions:
         Fee Scheme 10"},{"id":4,"start_date":"2018-12-31","end_date":"2020-09-16","type":"AGFS","description":"AGFS
         Fee Scheme 11"},{"id":5,"start_date":"2020-09-17","end_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 12 - CLAR accelerated measures"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:16 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:05 GMT
 recorded_with: VCR 6.0.0

--- a/spec/vcr/errors_spec.yml
+++ b/spec/vcr/errors_spec.yml
@@ -19,17 +19,17 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:50 GMT
+      - Wed, 20 Apr 2022 11:55:02 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '50'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -37,7 +37,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '["`case_date` should be in the format YYYY-MM-DD"]'
-  recorded_at: Wed, 03 Feb 2021 16:19:50 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:02 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/100/
@@ -57,17 +57,17 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:50 GMT
+      - Wed, 20 Apr 2022 11:55:02 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '23'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -75,50 +75,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
-  recorded_at: Wed, 03 Feb 2021 16:19:50 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:19:50 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '607'
-      Connection:
-      - keep-alive
-      Allow:
-      - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"count":5,"next":null,"previous":null,"results":[{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
-        Fee Scheme 9"},{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
-        Fee Scheme 2016-04"},{"id":3,"start_date":"2018-04-01","end_date":"2018-12-30","type":"AGFS","description":"AGFS
-        Fee Scheme 10"},{"id":4,"start_date":"2018-12-31","end_date":"2020-09-16","type":"AGFS","description":"AGFS
-        Fee Scheme 11"},{"id":5,"start_date":"2020-09-17","end_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 12 - CLAR accelerated measures"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:50 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:02 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/fee-types/1000/
@@ -138,7 +95,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:50 GMT
+      - Wed, 20 Apr 2022 11:55:02 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -146,17 +103,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
-  recorded_at: Wed, 03 Feb 2021 16:19:50 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:02 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/fee-types/?scenario=INVALID_DATATYPE
@@ -176,25 +133,25 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:50 GMT
+      - Wed, 20 Apr 2022 11:55:02 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '48'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '["''INVALID_DATATYPE'' is not a valid `scenario`"]'
-  recorded_at: Wed, 03 Feb 2021 16:19:50 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:02 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/fee-types/?scenario=100
@@ -214,7 +171,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:50 GMT
+      - Wed, 20 Apr 2022 11:55:02 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -222,17 +179,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '["''100'' is not a valid `scenario`"]'
-  recorded_at: Wed, 03 Feb 2021 16:19:50 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:02 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/units/1000/
@@ -252,17 +209,17 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:50 GMT
+      - Wed, 20 Apr 2022 11:55:02 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '23'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -270,7 +227,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
-  recorded_at: Wed, 03 Feb 2021 16:19:50 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:02 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/units/?scenario=INVALID_DATATYPE
@@ -290,17 +247,17 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:50 GMT
+      - Wed, 20 Apr 2022 11:55:02 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '48'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -308,7 +265,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '["''INVALID_DATATYPE'' is not a valid `scenario`"]'
-  recorded_at: Wed, 03 Feb 2021 16:19:50 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:02 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/units/?scenario=100
@@ -328,25 +285,25 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:50 GMT
+      - Wed, 20 Apr 2022 11:55:03 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '35'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '["''100'' is not a valid `scenario`"]'
-  recorded_at: Wed, 03 Feb 2021 16:19:50 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:03 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/modifier-types/1000/
@@ -366,7 +323,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:50 GMT
+      - Wed, 20 Apr 2022 11:55:03 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -374,17 +331,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
-  recorded_at: Wed, 03 Feb 2021 16:19:50 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:03 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/modifier-types/?scenario=INVALID_DATATYPE
@@ -404,17 +361,17 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:51 GMT
+      - Wed, 20 Apr 2022 11:55:03 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '48'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -422,7 +379,50 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '["''INVALID_DATATYPE'' is not a valid `scenario`"]'
-  recorded_at: Wed, 03 Feb 2021 16:19:51 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:03 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:55:03 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '607'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"count":5,"next":null,"previous":null,"results":[{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
+        Fee Scheme 9"},{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
+        Fee Scheme 2016-04"},{"id":3,"start_date":"2018-04-01","end_date":"2018-12-30","type":"AGFS","description":"AGFS
+        Fee Scheme 10"},{"id":4,"start_date":"2018-12-31","end_date":"2020-09-16","type":"AGFS","description":"AGFS
+        Fee Scheme 11"},{"id":5,"start_date":"2020-09-17","end_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 12 - CLAR accelerated measures"}]}'
+  recorded_at: Wed, 20 Apr 2022 11:55:03 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/modifier-types/?scenario=100
@@ -442,64 +442,25 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:51 GMT
+      - Wed, 20 Apr 2022 11:55:03 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '35'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '["''100'' is not a valid `scenario`"]'
-  recorded_at: Wed, 03 Feb 2021 16:19:51 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/?case_date=2018-01-01&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:19:51 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '158'
-      Connection:
-      - keep-alive
-      Allow:
-      - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
-        Fee Scheme 9"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:51 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:03 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -519,25 +480,25 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:51 GMT
+      - Wed, 20 Apr 2022 11:55:03 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '39'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '["`fee_type_code` is a required field"]'
-  recorded_at: Wed, 03 Feb 2021 16:19:51 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:03 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -557,7 +518,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:51 GMT
+      - Wed, 20 Apr 2022 11:55:03 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -565,17 +526,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '["`fee_type_code` is a required field"]'
-  recorded_at: Wed, 03 Feb 2021 16:19:51 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:03 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario
@@ -595,17 +556,17 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:51 GMT
+      - Wed, 20 Apr 2022 11:55:03 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '34'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -613,7 +574,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '["`scenario` is a required field"]'
-  recorded_at: Wed, 03 Feb 2021 16:19:51 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:03 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class&scenario=5
@@ -633,25 +594,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:51 GMT
+      - Wed, 20 Apr 2022 11:55:04 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '16'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":130.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:51 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:04 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -671,25 +632,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:51 GMT
+      - Wed, 20 Apr 2022 11:55:04 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '14'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":0.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:51 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:04 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=100
@@ -709,17 +670,17 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:51 GMT
+      - Wed, 20 Apr 2022 11:55:04 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '35'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -727,7 +688,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '["''100'' is not a valid `scenario`"]'
-  recorded_at: Wed, 03 Feb 2021 16:19:51 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:04 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=INVALID_FEE_TYPE_CODE&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -747,7 +708,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:51 GMT
+      - Wed, 20 Apr 2022 11:55:04 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -755,17 +716,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '["''INVALID_FEE_TYPE_CODE'' is not a valid `fee_type_code`"]'
-  recorded_at: Wed, 03 Feb 2021 16:19:51 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:04 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=INVALID_OFFENCE_CLASS&scenario=5
@@ -785,25 +746,25 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:51 GMT
+      - Wed, 20 Apr 2022 11:55:04 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '58'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '["''INVALID_OFFENCE_CLASS'' is not a valid `offence_class`"]'
-  recorded_at: Wed, 03 Feb 2021 16:19:51 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:04 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=INVALID_ADVOCATE_TYPE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -823,25 +784,64 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:51 GMT
+      - Wed, 20 Apr 2022 11:55:04 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '58'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '["''INVALID_ADVOCATE_TYPE'' is not a valid `advocate_type`"]'
-  recorded_at: Wed, 03 Feb 2021 16:19:51 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:04 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/?case_date=2018-01-01&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:55:04 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '158'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
+        Fee Scheme 9"}]}'
+  recorded_at: Wed, 20 Apr 2022 11:55:04 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&defendant=2&fee_type_code=AGFS_APPEAL_CON&fixed=2&halfday=2&hour=2&not_a_real_param=rubbish&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -861,23 +861,23 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:52 GMT
+      - Wed, 20 Apr 2022 11:55:04 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '16'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":130.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:52 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:04 GMT
 recorded_with: VCR 6.0.0

--- a/spec/vcr/fee_scheme_spec.yml
+++ b/spec/vcr/fee_scheme_spec.yml
@@ -19,23 +19,23 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:16 GMT
+      - Wed, 20 Apr 2022 11:54:05 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '16'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":130.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:16 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:05 GMT
 recorded_with: VCR 6.0.0

--- a/spec/vcr/fee_schemes_spec.yml
+++ b/spec/vcr/fee_schemes_spec.yml
@@ -19,19 +19,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:52 GMT
+      - Wed, 20 Apr 2022 11:55:05 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '607'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -42,7 +42,7 @@ http_interactions:
         Fee Scheme 10"},{"id":4,"start_date":"2018-12-31","end_date":"2020-09-16","type":"AGFS","description":"AGFS
         Fee Scheme 11"},{"id":5,"start_date":"2020-09-17","end_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 12 - CLAR accelerated measures"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:52 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:05 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/
@@ -62,7 +62,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:52 GMT
+      - Wed, 20 Apr 2022 11:55:05 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -70,18 +70,18 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
         Fee Scheme 9"}'
-  recorded_at: Wed, 03 Feb 2021 16:19:52 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:05 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/?type=AGFS
@@ -101,17 +101,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:52 GMT
+      - Wed, 20 Apr 2022 11:55:05 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '502'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -123,7 +123,7 @@ http_interactions:
         Fee Scheme 10"},{"id":4,"start_date":"2018-12-31","end_date":"2020-09-16","type":"AGFS","description":"AGFS
         Fee Scheme 11"},{"id":5,"start_date":"2020-09-17","end_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 12 - CLAR accelerated measures"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:52 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:05 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/?case_date=2018-01-01
@@ -143,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:52 GMT
+      - Wed, 20 Apr 2022 11:55:05 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -151,11 +151,11 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -163,7 +163,7 @@ http_interactions:
       string: '{"count":2,"next":null,"previous":null,"results":[{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
         Fee Scheme 9"},{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
         Fee Scheme 2016-04"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:52 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:05 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/?case_date=2018-01-01&type=LGFS
@@ -183,7 +183,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:52 GMT
+      - Wed, 20 Apr 2022 11:55:05 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -191,16 +191,16 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
         Fee Scheme 2016-04"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:52 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:05 GMT
 recorded_with: VCR 6.0.0

--- a/spec/vcr/fee_types_spec.yml
+++ b/spec/vcr/fee_types_spec.yml
@@ -2,119 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:19:52 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '106'
-      Connection:
-      - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
-      Allow:
-      - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
-        Fee Scheme 9"}'
-  recorded_at: Wed, 03 Feb 2021 16:19:52 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/fee-types/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:19:52 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '4205'
-      Connection:
-      - keep-alive
-      Allow:
-      - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"count":36,"next":null,"previous":null,"results":[{"id":4,"name":"Plea
-        and case management hearing","code":"AGFS_PLEA","is_basic":false,"aggregation":"sum"},{"id":5,"name":"Abuse
-        of process hearing (half day)","code":"AGFS_ABS_PRC_HF","is_basic":false,"aggregation":"sum"},{"id":6,"name":"Abuse
-        of process hearing (full day)","code":"AGFS_ABS_PRC_WL","is_basic":false,"aggregation":"sum"},{"id":7,"name":"Adjourned
-        appeals","code":"AGFS_ADJOURNED","is_basic":false,"aggregation":"sum"},{"id":8,"name":"Appeals
-        to crown court against conviction","code":"AGFS_APPEAL_CON","is_basic":false,"aggregation":"sum"},{"id":9,"name":"Appeals
-        to the crown court against sentence","code":"AGFS_APPEAL_SEN","is_basic":false,"aggregation":"sum"},{"id":10,"name":"Application
-        to dismiss a charge day 2 onwards (half day)","code":"AGFS_DMS_DY2_HF","is_basic":false,"aggregation":"sum"},{"id":11,"name":"Application
-        to dismiss a charge day 2 onwards (full day)","code":"AGFS_DMS_DY2_WL","is_basic":false,"aggregation":"sum"},{"id":12,"name":"Committal
-        for sentence hearing","code":"AGFS_COMMITTAL","is_basic":false,"aggregation":"sum"},{"id":13,"name":"Conferences
-        and views (hours)","code":"AGFS_CONFERENCE","is_basic":false,"aggregation":"sum"},{"id":14,"name":"Contempt
-        hearings","code":"AGFS_CONTEMPT","is_basic":false,"aggregation":"sum"},{"id":15,"name":"Contempt
-        hearings (apportioned)","code":"AGFS_CNTMPT_APP","is_basic":false,"aggregation":"sum"},{"id":16,"name":"Deferred
-        sentence hearings","code":"AGFS_DEF_SEN_HR","is_basic":false,"aggregation":"sum"},{"id":17,"name":"Hearings
-        relating to admissibility of evidence (full day)","code":"AGFS_ADM_EVD_WL","is_basic":false,"aggregation":"sum"},{"id":18,"name":"Hearings
-        relating to disclosure (half day)","code":"AGFS_DISC_HALF","is_basic":false,"aggregation":"sum"},{"id":19,"name":"Hearings
-        relating to disclosure (full day)","code":"AGFS_DISC_FULL","is_basic":false,"aggregation":"sum"},{"id":20,"name":"Noting
-        brief","code":"AGFS_NOTING_BRF","is_basic":false,"aggregation":"sum"},{"id":21,"name":"Paper
-        plea and case management","code":"AGFS_PAPER_PLEA","is_basic":false,"aggregation":"sum"},{"id":22,"name":"Proceeds
-        relating to breach of an order of the crown court","code":"AGFS_ORDER_BRCH","is_basic":false,"aggregation":"sum"},{"id":23,"name":"Public
-        interest immunity hearing (half day)","code":"AGFS_PI_IMMN_HF","is_basic":false,"aggregation":"sum"},{"id":24,"name":"Public
-        interest immunity hearing (full day)","code":"AGFS_PI_IMMN_WL","is_basic":false,"aggregation":"sum"},{"id":25,"name":"Research
-        of very unusual or novel factual issue","code":"AGFS_NOVELISSUE","is_basic":false,"aggregation":"sum"},{"id":26,"name":"Research
-        of very unusual of novel point of law","code":"AGFS_NOVEL_LAW","is_basic":false,"aggregation":"sum"},{"id":27,"name":"Standard
-        appearance fee","code":"AGFS_STD_APPRNC","is_basic":false,"aggregation":"sum"},{"id":28,"name":"Sentence
-        hearing","code":"AGFS_SENTENCE","is_basic":false,"aggregation":"sum"},{"id":29,"name":"Special
-        preperation (hourly)","code":"AGFS_SPCL_PREP","is_basic":false,"aggregation":"sum"},{"id":30,"name":"Trial
-        not proceed","code":"AGFS_NOT_PRCD","is_basic":false,"aggregation":"sum"},{"id":31,"name":"Unsuccesful
-        application to vacate a guilty plea (half day)","code":"AGFS_UN_VAC_HF","is_basic":false,"aggregation":"sum"},{"id":32,"name":"Unsuccesful
-        application to vacate a guilty plea (full day)","code":"AGFS_UN_VAC_WL","is_basic":false,"aggregation":"sum"},{"id":33,"name":"Written
-        / oral advice","code":"AGFS_WRTN_ORAL","is_basic":false,"aggregation":"sum"},{"id":34,"name":"Advocate
-        fee","code":"AGFS_FEE","is_basic":true,"aggregation":"sum"},{"id":36,"name":"Staged
-        payments","code":"AGFS_STAGED","is_basic":false,"aggregation":"sum"},{"id":83,"name":"Confiscation
-        (half day)","code":"AGFS_CONFISC_HF","is_basic":false,"aggregation":"sum"},{"id":85,"name":"Confiscation
-        (full day)","code":"AGFS_CONFISC_WL","is_basic":false,"aggregation":"sum"},{"id":90,"name":"Hearings
-        relating to admissibility of evidence (half day)","code":"AGFS_ADM_EVD_HF","is_basic":false,"aggregation":"sum"},{"id":91,"name":"Wasted
-        preparation fee","code":"AGFS_WSTD_PREP","is_basic":false,"aggregation":"sum"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:52 GMT
-- request:
-    method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/fee-types/4/
     body:
       encoding: US-ASCII
@@ -132,25 +19,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:52 GMT
+      - Wed, 20 Apr 2022 11:55:06 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '106'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"id":4,"name":"Plea and case management hearing","code":"AGFS_PLEA","is_basic":false,"aggregation":"sum"}'
-  recorded_at: Wed, 03 Feb 2021 16:19:52 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:06 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/fee-types/?is_basic=true
@@ -170,7 +57,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:52 GMT
+      - Wed, 20 Apr 2022 11:55:06 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -178,18 +65,18 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":34,"name":"Advocate
         fee","code":"AGFS_FEE","is_basic":true,"aggregation":"sum"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:52 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:06 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/fee-types/?scenario=1
@@ -209,19 +96,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:52 GMT
+      - Wed, 20 Apr 2022 11:55:06 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '3498'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -257,7 +144,7 @@ http_interactions:
         (full day)","code":"AGFS_CONFISC_WL","is_basic":false,"aggregation":"sum"},{"id":90,"name":"Hearings
         relating to admissibility of evidence (half day)","code":"AGFS_ADM_EVD_HF","is_basic":false,"aggregation":"sum"},{"id":91,"name":"Wasted
         preparation fee","code":"AGFS_WSTD_PREP","is_basic":false,"aggregation":"sum"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:52 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:06 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/fee-types/?advocate_type=QC
@@ -277,17 +164,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:52 GMT
+      - Wed, 20 Apr 2022 11:55:06 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '4205'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -331,7 +218,7 @@ http_interactions:
         (full day)","code":"AGFS_CONFISC_WL","is_basic":false,"aggregation":"sum"},{"id":90,"name":"Hearings
         relating to admissibility of evidence (half day)","code":"AGFS_ADM_EVD_HF","is_basic":false,"aggregation":"sum"},{"id":91,"name":"Wasted
         preparation fee","code":"AGFS_WSTD_PREP","is_basic":false,"aggregation":"sum"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:52 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:06 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/fee-types/?offence_class=A
@@ -351,17 +238,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:52 GMT
+      - Wed, 20 Apr 2022 11:55:07 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '4205'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -405,7 +292,7 @@ http_interactions:
         (full day)","code":"AGFS_CONFISC_WL","is_basic":false,"aggregation":"sum"},{"id":90,"name":"Hearings
         relating to admissibility of evidence (half day)","code":"AGFS_ADM_EVD_HF","is_basic":false,"aggregation":"sum"},{"id":91,"name":"Wasted
         preparation fee","code":"AGFS_WSTD_PREP","is_basic":false,"aggregation":"sum"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:52 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:07 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/fee-types/?fee_type_code=AGFS_FEE
@@ -425,26 +312,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:53 GMT
+      - Wed, 20 Apr 2022 11:55:07 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '137'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":34,"name":"Advocate
         fee","code":"AGFS_FEE","is_basic":true,"aggregation":"sum"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:53 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:07 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/fee-types/1001/
@@ -464,7 +351,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:53 GMT
+      - Wed, 20 Apr 2022 11:55:07 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -472,17 +359,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
-  recorded_at: Wed, 03 Feb 2021 16:19:53 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:07 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/fee-types/?is_basic=true&scenario=8
@@ -502,25 +389,138 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:53 GMT
+      - Wed, 20 Apr 2022 11:55:07 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '52'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"count":0,"next":null,"previous":null,"results":[]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:53 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:07 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/fee-types/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:55:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4205'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"count":36,"next":null,"previous":null,"results":[{"id":4,"name":"Plea
+        and case management hearing","code":"AGFS_PLEA","is_basic":false,"aggregation":"sum"},{"id":5,"name":"Abuse
+        of process hearing (half day)","code":"AGFS_ABS_PRC_HF","is_basic":false,"aggregation":"sum"},{"id":6,"name":"Abuse
+        of process hearing (full day)","code":"AGFS_ABS_PRC_WL","is_basic":false,"aggregation":"sum"},{"id":7,"name":"Adjourned
+        appeals","code":"AGFS_ADJOURNED","is_basic":false,"aggregation":"sum"},{"id":8,"name":"Appeals
+        to crown court against conviction","code":"AGFS_APPEAL_CON","is_basic":false,"aggregation":"sum"},{"id":9,"name":"Appeals
+        to the crown court against sentence","code":"AGFS_APPEAL_SEN","is_basic":false,"aggregation":"sum"},{"id":10,"name":"Application
+        to dismiss a charge day 2 onwards (half day)","code":"AGFS_DMS_DY2_HF","is_basic":false,"aggregation":"sum"},{"id":11,"name":"Application
+        to dismiss a charge day 2 onwards (full day)","code":"AGFS_DMS_DY2_WL","is_basic":false,"aggregation":"sum"},{"id":12,"name":"Committal
+        for sentence hearing","code":"AGFS_COMMITTAL","is_basic":false,"aggregation":"sum"},{"id":13,"name":"Conferences
+        and views (hours)","code":"AGFS_CONFERENCE","is_basic":false,"aggregation":"sum"},{"id":14,"name":"Contempt
+        hearings","code":"AGFS_CONTEMPT","is_basic":false,"aggregation":"sum"},{"id":15,"name":"Contempt
+        hearings (apportioned)","code":"AGFS_CNTMPT_APP","is_basic":false,"aggregation":"sum"},{"id":16,"name":"Deferred
+        sentence hearings","code":"AGFS_DEF_SEN_HR","is_basic":false,"aggregation":"sum"},{"id":17,"name":"Hearings
+        relating to admissibility of evidence (full day)","code":"AGFS_ADM_EVD_WL","is_basic":false,"aggregation":"sum"},{"id":18,"name":"Hearings
+        relating to disclosure (half day)","code":"AGFS_DISC_HALF","is_basic":false,"aggregation":"sum"},{"id":19,"name":"Hearings
+        relating to disclosure (full day)","code":"AGFS_DISC_FULL","is_basic":false,"aggregation":"sum"},{"id":20,"name":"Noting
+        brief","code":"AGFS_NOTING_BRF","is_basic":false,"aggregation":"sum"},{"id":21,"name":"Paper
+        plea and case management","code":"AGFS_PAPER_PLEA","is_basic":false,"aggregation":"sum"},{"id":22,"name":"Proceeds
+        relating to breach of an order of the crown court","code":"AGFS_ORDER_BRCH","is_basic":false,"aggregation":"sum"},{"id":23,"name":"Public
+        interest immunity hearing (half day)","code":"AGFS_PI_IMMN_HF","is_basic":false,"aggregation":"sum"},{"id":24,"name":"Public
+        interest immunity hearing (full day)","code":"AGFS_PI_IMMN_WL","is_basic":false,"aggregation":"sum"},{"id":25,"name":"Research
+        of very unusual or novel factual issue","code":"AGFS_NOVELISSUE","is_basic":false,"aggregation":"sum"},{"id":26,"name":"Research
+        of very unusual of novel point of law","code":"AGFS_NOVEL_LAW","is_basic":false,"aggregation":"sum"},{"id":27,"name":"Standard
+        appearance fee","code":"AGFS_STD_APPRNC","is_basic":false,"aggregation":"sum"},{"id":28,"name":"Sentence
+        hearing","code":"AGFS_SENTENCE","is_basic":false,"aggregation":"sum"},{"id":29,"name":"Special
+        preperation (hourly)","code":"AGFS_SPCL_PREP","is_basic":false,"aggregation":"sum"},{"id":30,"name":"Trial
+        not proceed","code":"AGFS_NOT_PRCD","is_basic":false,"aggregation":"sum"},{"id":31,"name":"Unsuccesful
+        application to vacate a guilty plea (half day)","code":"AGFS_UN_VAC_HF","is_basic":false,"aggregation":"sum"},{"id":32,"name":"Unsuccesful
+        application to vacate a guilty plea (full day)","code":"AGFS_UN_VAC_WL","is_basic":false,"aggregation":"sum"},{"id":33,"name":"Written
+        / oral advice","code":"AGFS_WRTN_ORAL","is_basic":false,"aggregation":"sum"},{"id":34,"name":"Advocate
+        fee","code":"AGFS_FEE","is_basic":true,"aggregation":"sum"},{"id":36,"name":"Staged
+        payments","code":"AGFS_STAGED","is_basic":false,"aggregation":"sum"},{"id":83,"name":"Confiscation
+        (half day)","code":"AGFS_CONFISC_HF","is_basic":false,"aggregation":"sum"},{"id":85,"name":"Confiscation
+        (full day)","code":"AGFS_CONFISC_WL","is_basic":false,"aggregation":"sum"},{"id":90,"name":"Hearings
+        relating to admissibility of evidence (half day)","code":"AGFS_ADM_EVD_HF","is_basic":false,"aggregation":"sum"},{"id":91,"name":"Wasted
+        preparation fee","code":"AGFS_WSTD_PREP","is_basic":false,"aggregation":"sum"}]}'
+  recorded_at: Wed, 20 Apr 2022 11:55:07 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:55:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '106'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
+        Fee Scheme 9"}'
+  recorded_at: Wed, 20 Apr 2022 11:55:07 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/fee-types/?scenario=8
@@ -540,7 +540,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:53 GMT
+      - Wed, 20 Apr 2022 11:55:07 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -548,11 +548,11 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -587,5 +587,5 @@ http_interactions:
         payments","code":"AGFS_STAGED","is_basic":false,"aggregation":"sum"},{"id":90,"name":"Hearings
         relating to admissibility of evidence (half day)","code":"AGFS_ADM_EVD_HF","is_basic":false,"aggregation":"sum"},{"id":91,"name":"Wasted
         preparation fee","code":"AGFS_WSTD_PREP","is_basic":false,"aggregation":"sum"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:53 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:07 GMT
 recorded_with: VCR 6.0.0

--- a/spec/vcr/fixed_fees_spec.yml
+++ b/spec/vcr/fixed_fees_spec.yml
@@ -2,83 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/?case_date=2018-01-01&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:19:16 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '158'
-      Connection:
-      - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
-      Allow:
-      - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
-        Fee Scheme 9"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:16 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:19:16 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '16'
-      Connection:
-      - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
-      Allow:
-      - GET
-      Vary:
-      - Accept, Cookie
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"amount":130.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:16 GMT
-- request:
-    method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
     body:
       encoding: US-ASCII
@@ -96,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:17 GMT
+      - Wed, 20 Apr 2022 11:54:07 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -104,17 +27,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":130.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:17 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:07 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -134,25 +57,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:17 GMT
+      - Wed, 20 Apr 2022 11:54:07 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '16'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":195.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:17 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:07 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -172,17 +95,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:17 GMT
+      - Wed, 20 Apr 2022 11:54:07 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '16'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -190,7 +113,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":260.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:17 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:07 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=INVALID&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -210,7 +133,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:17 GMT
+      - Wed, 20 Apr 2022 11:54:07 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -218,17 +141,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '["''INVALID'' is not a valid `advocate_type`"]'
-  recorded_at: Wed, 03 Feb 2021 16:19:17 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:07 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=30&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -248,7 +171,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:17 GMT
+      - Wed, 20 Apr 2022 11:54:07 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -256,17 +179,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":3900.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:17 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:07 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=31&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -286,25 +209,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:17 GMT
+      - Wed, 20 Apr 2022 11:54:08 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":3900.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:17 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:08 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=2&offence_class=E&scenario=5
@@ -324,17 +247,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:17 GMT
+      - Wed, 20 Apr 2022 11:54:08 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '16'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -342,7 +265,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":156.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:17 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:08 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=3&offence_class=E&scenario=5
@@ -362,17 +285,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:17 GMT
+      - Wed, 20 Apr 2022 11:54:08 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '16'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -380,7 +303,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":182.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:17 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:08 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=4&offence_class=E&scenario=5
@@ -400,17 +323,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:17 GMT
+      - Wed, 20 Apr 2022 11:54:08 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '16'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -418,7 +341,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":208.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:17 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:08 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=5&offence_class=E&scenario=5
@@ -438,25 +361,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:17 GMT
+      - Wed, 20 Apr 2022 11:54:08 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '16'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":234.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:17 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:08 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=10&offence_class=E&scenario=5
@@ -476,17 +399,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:17 GMT
+      - Wed, 20 Apr 2022 11:54:08 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '16'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -494,7 +417,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":364.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:17 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:08 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=100&offence_class=E&scenario=5
@@ -514,7 +437,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:17 GMT
+      - Wed, 20 Apr 2022 11:54:09 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -522,17 +445,55 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2704.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:17 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:09 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:54:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"amount":130.0}'
+  recorded_at: Wed, 20 Apr 2022 11:54:09 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=2&number_of_defendants=1&offence_class=E&scenario=5
@@ -552,17 +513,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:18 GMT
+      - Wed, 20 Apr 2022 11:54:09 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '16'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -570,7 +531,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":156.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:18 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:09 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=3&number_of_defendants=1&offence_class=E&scenario=5
@@ -590,7 +551,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:18 GMT
+      - Wed, 20 Apr 2022 11:54:09 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -598,17 +559,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":182.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:18 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:09 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=4&number_of_defendants=1&offence_class=E&scenario=5
@@ -628,7 +589,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:18 GMT
+      - Wed, 20 Apr 2022 11:54:09 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -636,17 +597,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":208.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:18 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:09 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=5&number_of_defendants=1&offence_class=E&scenario=5
@@ -666,25 +627,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:18 GMT
+      - Wed, 20 Apr 2022 11:54:09 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '16'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":234.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:18 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:09 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=10&number_of_defendants=1&offence_class=E&scenario=5
@@ -704,25 +665,64 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:18 GMT
+      - Wed, 20 Apr 2022 11:54:09 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '16'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":364.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:18 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:09 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/?case_date=2018-01-01&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:54:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '158'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
+        Fee Scheme 9"}]}'
+  recorded_at: Wed, 20 Apr 2022 11:54:09 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_APPEAL_CON&number_of_cases=100&number_of_defendants=1&offence_class=E&scenario=5
@@ -742,17 +742,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:18 GMT
+      - Wed, 20 Apr 2022 11:54:09 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -760,84 +760,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":2704.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:18 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/?case_date=2018-01-01&type=LGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:19:42 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '156'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Allow:
-      - GET, HEAD, OPTIONS
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
-        Fee Scheme 2016-04"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:42 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:19:42 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '17'
-      Connection:
-      - keep-alive
-      Allow:
-      - GET
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"amount":349.47}'
-  recorded_at: Wed, 03 Feb 2021 16:19:42 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:09 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=10&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -857,25 +780,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:42 GMT
+      - Wed, 20 Apr 2022 11:54:51 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":349.47}'
-  recorded_at: Wed, 03 Feb 2021 16:19:42 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:51 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=100&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
@@ -895,25 +818,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:42 GMT
+      - Wed, 20 Apr 2022 11:54:51 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":349.47}'
-  recorded_at: Wed, 03 Feb 2021 16:19:42 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:51 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=10&offence_class=E&scenario=5
@@ -933,25 +856,102 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:42 GMT
+      - Wed, 20 Apr 2022 11:54:52 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":349.47}'
-  recorded_at: Wed, 03 Feb 2021 16:19:42 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:52 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&scenario=5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:54:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '17'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"amount":349.47}'
+  recorded_at: Wed, 20 Apr 2022 11:54:52 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/?case_date=2018-01-01&type=LGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:54:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
+        Fee Scheme 2016-04"}]}'
+  recorded_at: Wed, 20 Apr 2022 11:54:52 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=10&number_of_defendants=1&offence_class=E&scenario=5
@@ -971,7 +971,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:43 GMT
+      - Wed, 20 Apr 2022 11:54:52 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -979,15 +979,15 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":349.47}'
-  recorded_at: Wed, 03 Feb 2021 16:19:43 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:52 GMT
 recorded_with: VCR 6.0.0

--- a/spec/vcr/graduated_fees_spec.yml
+++ b/spec/vcr/graduated_fees_spec.yml
@@ -2,83 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/?case_date=2018-01-01&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:19:18 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '158'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Allow:
-      - GET, HEAD, OPTIONS
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
-        Fee Scheme 9"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:18 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:19:18 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '17'
-      Connection:
-      - keep-alive
-      Allow:
-      - GET
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"amount":1632.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:18 GMT
-- request:
-    method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=2&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
     body:
       encoding: US-ASCII
@@ -96,17 +19,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:18 GMT
+      - Wed, 20 Apr 2022 11:54:10 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -114,7 +37,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1632.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:18 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:10 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -134,17 +57,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:18 GMT
+      - Wed, 20 Apr 2022 11:54:11 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -152,7 +75,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":3835.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:18 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:11 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -172,17 +95,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:18 GMT
+      - Wed, 20 Apr 2022 11:54:11 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -190,7 +113,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":40058.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:18 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:11 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=1&pw=1&scenario=4
@@ -210,17 +133,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:19 GMT
+      - Wed, 20 Apr 2022 11:54:11 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -228,7 +151,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":3386.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:19 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:11 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=1&pw=1&scenario=4
@@ -248,25 +171,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:19 GMT
+      - Wed, 20 Apr 2022 11:54:11 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":35095.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:19 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:11 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=C&ppe=1&pw=1&scenario=4
@@ -286,25 +209,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:19 GMT
+      - Wed, 20 Apr 2022 11:54:12 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2784.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:19 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:12 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=C&ppe=1&pw=1&scenario=4
@@ -324,25 +247,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:19 GMT
+      - Wed, 20 Apr 2022 11:54:12 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":32976.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:19 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:12 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=D&ppe=1&pw=1&scenario=4
@@ -362,7 +285,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:19 GMT
+      - Wed, 20 Apr 2022 11:54:12 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -370,17 +293,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":3100.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:19 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:12 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=D&ppe=1&pw=1&scenario=4
@@ -400,17 +323,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:19 GMT
+      - Wed, 20 Apr 2022 11:54:12 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -418,7 +341,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":33292.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:19 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:12 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&ppe=1&pw=1&scenario=4
@@ -438,17 +361,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:19 GMT
+      - Wed, 20 Apr 2022 11:54:13 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -456,7 +379,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":2126.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:19 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:13 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&ppe=1&pw=1&scenario=4
@@ -476,25 +399,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:19 GMT
+      - Wed, 20 Apr 2022 11:54:13 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":24770.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:19 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:13 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=F&ppe=1&pw=1&scenario=4
@@ -514,7 +437,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:19 GMT
+      - Wed, 20 Apr 2022 11:54:13 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -522,17 +445,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2126.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:19 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:13 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=F&ppe=1&pw=1&scenario=4
@@ -552,7 +475,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:19 GMT
+      - Wed, 20 Apr 2022 11:54:13 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -560,17 +483,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":24770.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:19 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:13 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=G&ppe=1&pw=1&scenario=4
@@ -590,7 +513,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:19 GMT
+      - Wed, 20 Apr 2022 11:54:14 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -598,17 +521,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2126.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:19 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:14 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=G&ppe=1&pw=1&scenario=4
@@ -628,7 +551,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:20 GMT
+      - Wed, 20 Apr 2022 11:54:14 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -636,17 +559,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":24770.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:20 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:14 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=H&ppe=1&pw=1&scenario=4
@@ -666,25 +589,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:20 GMT
+      - Wed, 20 Apr 2022 11:54:14 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2719.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:20 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:14 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=H&ppe=1&pw=1&scenario=4
@@ -704,7 +627,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:20 GMT
+      - Wed, 20 Apr 2022 11:54:15 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -712,17 +635,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":32911.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:20 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:15 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=I&ppe=1&pw=1&scenario=4
@@ -742,7 +665,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:20 GMT
+      - Wed, 20 Apr 2022 11:54:15 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -750,17 +673,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2938.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:20 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:15 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=I&ppe=1&pw=1&scenario=4
@@ -780,17 +703,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:20 GMT
+      - Wed, 20 Apr 2022 11:54:15 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -798,7 +721,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":33130.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:20 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:15 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=J&ppe=1&pw=1&scenario=4
@@ -818,17 +741,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:20 GMT
+      - Wed, 20 Apr 2022 11:54:15 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -836,7 +759,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":3835.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:20 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:15 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=J&ppe=1&pw=1&scenario=4
@@ -856,17 +779,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:20 GMT
+      - Wed, 20 Apr 2022 11:54:16 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -874,7 +797,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":40058.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:20 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:16 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=K&ppe=1&pw=1&scenario=4
@@ -894,25 +817,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:20 GMT
+      - Wed, 20 Apr 2022 11:54:16 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":3835.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:20 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:16 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=K&ppe=1&pw=1&scenario=4
@@ -932,17 +855,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:20 GMT
+      - Wed, 20 Apr 2022 11:54:16 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -950,7 +873,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":40058.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:20 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:16 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -970,25 +893,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:21 GMT
+      - Wed, 20 Apr 2022 11:54:16 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2876.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:21 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:16 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -1008,7 +931,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:21 GMT
+      - Wed, 20 Apr 2022 11:54:17 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -1016,17 +939,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":30034.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:21 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:17 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=1&pw=1&scenario=4
@@ -1046,17 +969,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:21 GMT
+      - Wed, 20 Apr 2022 11:54:17 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -1064,7 +987,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":2540.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:21 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:17 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=1&pw=1&scenario=4
@@ -1084,17 +1007,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:21 GMT
+      - Wed, 20 Apr 2022 11:54:17 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -1102,7 +1025,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":26331.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:21 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:17 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=C&ppe=1&pw=1&scenario=4
@@ -1122,7 +1045,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:21 GMT
+      - Wed, 20 Apr 2022 11:54:17 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -1130,17 +1053,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2088.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:21 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:17 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=C&ppe=1&pw=1&scenario=4
@@ -1160,7 +1083,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:21 GMT
+      - Wed, 20 Apr 2022 11:54:18 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -1168,17 +1091,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":24732.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:21 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:18 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=D&ppe=1&pw=1&scenario=4
@@ -1198,25 +1121,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:21 GMT
+      - Wed, 20 Apr 2022 11:54:18 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2326.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:21 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:18 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=D&ppe=1&pw=1&scenario=4
@@ -1236,7 +1159,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:21 GMT
+      - Wed, 20 Apr 2022 11:54:18 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -1244,17 +1167,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":24970.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:21 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:18 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&ppe=1&pw=1&scenario=4
@@ -1274,17 +1197,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:21 GMT
+      - Wed, 20 Apr 2022 11:54:19 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -1292,7 +1215,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1595.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:21 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:19 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&ppe=1&pw=1&scenario=4
@@ -1312,25 +1235,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:22 GMT
+      - Wed, 20 Apr 2022 11:54:19 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":18578.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:22 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:19 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=F&ppe=1&pw=1&scenario=4
@@ -1350,17 +1273,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:22 GMT
+      - Wed, 20 Apr 2022 11:54:19 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -1368,7 +1291,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1595.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:22 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:19 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=F&ppe=1&pw=1&scenario=4
@@ -1388,7 +1311,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:22 GMT
+      - Wed, 20 Apr 2022 11:54:19 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -1396,17 +1319,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":18578.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:22 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:19 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=G&ppe=1&pw=1&scenario=4
@@ -1426,25 +1349,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:22 GMT
+      - Wed, 20 Apr 2022 11:54:20 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1595.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:22 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:20 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=G&ppe=1&pw=1&scenario=4
@@ -1464,17 +1387,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:22 GMT
+      - Wed, 20 Apr 2022 11:54:20 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -1482,7 +1405,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":18578.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:22 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:20 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=H&ppe=1&pw=1&scenario=4
@@ -1502,17 +1425,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:22 GMT
+      - Wed, 20 Apr 2022 11:54:20 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -1520,7 +1443,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":2039.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:22 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:20 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=H&ppe=1&pw=1&scenario=4
@@ -1540,25 +1463,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:22 GMT
+      - Wed, 20 Apr 2022 11:54:21 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":24683.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:22 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:21 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=I&ppe=1&pw=1&scenario=4
@@ -1578,25 +1501,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:22 GMT
+      - Wed, 20 Apr 2022 11:54:21 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2204.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:22 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:21 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=I&ppe=1&pw=1&scenario=4
@@ -1616,7 +1539,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:23 GMT
+      - Wed, 20 Apr 2022 11:54:21 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -1624,17 +1547,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":24848.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:23 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:21 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=J&ppe=1&pw=1&scenario=4
@@ -1654,17 +1577,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:23 GMT
+      - Wed, 20 Apr 2022 11:54:21 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -1672,7 +1595,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":2876.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:23 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:21 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=J&ppe=1&pw=1&scenario=4
@@ -1692,7 +1615,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:23 GMT
+      - Wed, 20 Apr 2022 11:54:22 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -1700,17 +1623,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":30034.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:23 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:22 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=K&ppe=1&pw=1&scenario=4
@@ -1730,25 +1653,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:23 GMT
+      - Wed, 20 Apr 2022 11:54:22 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2876.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:23 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:22 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=K&ppe=1&pw=1&scenario=4
@@ -1768,25 +1691,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:23 GMT
+      - Wed, 20 Apr 2022 11:54:22 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":30034.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:23 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:22 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -1806,25 +1729,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:23 GMT
+      - Wed, 20 Apr 2022 11:54:23 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2122.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:23 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:23 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -1844,17 +1767,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:23 GMT
+      - Wed, 20 Apr 2022 11:54:23 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -1862,7 +1785,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":20252.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:23 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:23 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=1&pw=1&scenario=4
@@ -1882,25 +1805,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:24 GMT
+      - Wed, 20 Apr 2022 11:54:23 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1693.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:24 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:23 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=1&pw=1&scenario=4
@@ -1920,7 +1843,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:24 GMT
+      - Wed, 20 Apr 2022 11:54:23 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -1928,17 +1851,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":17529.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:24 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:23 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=C&ppe=1&pw=1&scenario=4
@@ -1958,17 +1881,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:24 GMT
+      - Wed, 20 Apr 2022 11:54:24 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -1976,7 +1899,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1306.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:24 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:24 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=C&ppe=1&pw=1&scenario=4
@@ -1996,25 +1919,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:24 GMT
+      - Wed, 20 Apr 2022 11:54:24 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":16402.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:24 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:24 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=D&ppe=1&pw=1&scenario=4
@@ -2034,17 +1957,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:24 GMT
+      - Wed, 20 Apr 2022 11:54:24 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -2052,7 +1975,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1533.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:24 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:24 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=D&ppe=1&pw=1&scenario=4
@@ -2072,25 +1995,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:24 GMT
+      - Wed, 20 Apr 2022 11:54:24 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":16629.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:24 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:24 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&ppe=1&pw=1&scenario=4
@@ -2110,25 +2033,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:24 GMT
+      - Wed, 20 Apr 2022 11:54:25 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1000.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:24 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:25 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&ppe=1&pw=1&scenario=4
@@ -2148,7 +2071,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:25 GMT
+      - Wed, 20 Apr 2022 11:54:25 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -2156,17 +2079,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":12322.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:25 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:25 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=F&ppe=1&pw=1&scenario=4
@@ -2186,17 +2109,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:25 GMT
+      - Wed, 20 Apr 2022 11:54:25 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -2204,7 +2127,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1000.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:25 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:25 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=F&ppe=1&pw=1&scenario=4
@@ -2224,7 +2147,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:25 GMT
+      - Wed, 20 Apr 2022 11:54:26 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -2232,17 +2155,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":12322.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:25 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:26 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=G&ppe=1&pw=1&scenario=4
@@ -2262,25 +2185,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:25 GMT
+      - Wed, 20 Apr 2022 11:54:26 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1000.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:25 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:26 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=G&ppe=1&pw=1&scenario=4
@@ -2300,25 +2223,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:25 GMT
+      - Wed, 20 Apr 2022 11:54:26 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":12322.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:25 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:26 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=H&ppe=1&pw=1&scenario=4
@@ -2338,17 +2261,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:25 GMT
+      - Wed, 20 Apr 2022 11:54:26 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -2356,7 +2279,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1224.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:25 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:26 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=H&ppe=1&pw=1&scenario=4
@@ -2376,7 +2299,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:25 GMT
+      - Wed, 20 Apr 2022 11:54:27 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -2384,17 +2307,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":16320.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:25 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:27 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=I&ppe=1&pw=1&scenario=4
@@ -2414,25 +2337,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:26 GMT
+      - Wed, 20 Apr 2022 11:54:27 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1387.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:26 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:27 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=I&ppe=1&pw=1&scenario=4
@@ -2452,7 +2375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:26 GMT
+      - Wed, 20 Apr 2022 11:54:27 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -2460,17 +2383,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":16483.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:26 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:27 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=J&ppe=1&pw=1&scenario=4
@@ -2490,25 +2413,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:26 GMT
+      - Wed, 20 Apr 2022 11:54:28 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2122.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:26 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:28 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=J&ppe=1&pw=1&scenario=4
@@ -2528,17 +2451,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:26 GMT
+      - Wed, 20 Apr 2022 11:54:28 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -2546,7 +2469,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":20252.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:26 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:28 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=K&ppe=1&pw=1&scenario=4
@@ -2566,25 +2489,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:26 GMT
+      - Wed, 20 Apr 2022 11:54:28 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1918.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:26 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:28 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=K&ppe=1&pw=1&scenario=4
@@ -2604,7 +2527,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:26 GMT
+      - Wed, 20 Apr 2022 11:54:29 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -2612,17 +2535,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":20048.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:26 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:29 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -2642,25 +2565,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:26 GMT
+      - Wed, 20 Apr 2022 11:54:29 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2162.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:26 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:29 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -2680,7 +2603,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:27 GMT
+      - Wed, 20 Apr 2022 11:54:29 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -2688,17 +2611,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":21772.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:27 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:29 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=1&pw=1&scenario=4
@@ -2718,17 +2641,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:27 GMT
+      - Wed, 20 Apr 2022 11:54:29 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -2736,7 +2659,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1774.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:27 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:29 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=1&pw=1&scenario=4
@@ -2756,7 +2679,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:27 GMT
+      - Wed, 20 Apr 2022 11:54:30 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -2764,17 +2687,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":19127.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:27 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:30 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=C&ppe=1&pw=1&scenario=4
@@ -2794,7 +2717,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:27 GMT
+      - Wed, 20 Apr 2022 11:54:30 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -2802,17 +2725,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1306.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:27 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:30 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=C&ppe=1&pw=1&scenario=4
@@ -2832,7 +2755,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:27 GMT
+      - Wed, 20 Apr 2022 11:54:30 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -2840,17 +2763,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":16402.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:27 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:30 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=D&ppe=1&pw=1&scenario=4
@@ -2870,25 +2793,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:28 GMT
+      - Wed, 20 Apr 2022 11:54:30 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1533.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:28 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:30 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=D&ppe=1&pw=1&scenario=4
@@ -2908,17 +2831,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:28 GMT
+      - Wed, 20 Apr 2022 11:54:31 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -2926,7 +2849,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":16629.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:28 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:31 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&ppe=1&pw=1&scenario=4
@@ -2946,25 +2869,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:28 GMT
+      - Wed, 20 Apr 2022 11:54:31 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '16'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":979.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:28 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:31 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=E&ppe=1&pw=1&scenario=4
@@ -2984,17 +2907,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:28 GMT
+      - Wed, 20 Apr 2022 11:54:31 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -3002,7 +2925,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":13041.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:28 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:31 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=F&ppe=1&pw=1&scenario=4
@@ -3022,17 +2945,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:28 GMT
+      - Wed, 20 Apr 2022 11:54:31 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -3040,7 +2963,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1020.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:28 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:31 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=F&ppe=1&pw=1&scenario=4
@@ -3060,17 +2983,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:28 GMT
+      - Wed, 20 Apr 2022 11:54:32 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -3078,7 +3001,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":13082.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:28 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:32 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=G&ppe=1&pw=1&scenario=4
@@ -3098,17 +3021,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:29 GMT
+      - Wed, 20 Apr 2022 11:54:32 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -3116,7 +3039,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1020.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:29 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:32 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=G&ppe=1&pw=1&scenario=4
@@ -3136,25 +3059,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:29 GMT
+      - Wed, 20 Apr 2022 11:54:32 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":13082.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:29 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:32 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=H&ppe=1&pw=1&scenario=4
@@ -3174,25 +3097,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:29 GMT
+      - Wed, 20 Apr 2022 11:54:32 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1224.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:29 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:32 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=H&ppe=1&pw=1&scenario=4
@@ -3212,17 +3135,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:29 GMT
+      - Wed, 20 Apr 2022 11:54:33 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -3230,7 +3153,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":16320.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:29 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:33 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=I&ppe=1&pw=1&scenario=4
@@ -3250,25 +3173,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:29 GMT
+      - Wed, 20 Apr 2022 11:54:33 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1387.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:29 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:33 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=I&ppe=1&pw=1&scenario=4
@@ -3288,7 +3211,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:29 GMT
+      - Wed, 20 Apr 2022 11:54:33 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -3296,17 +3219,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":16483.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:29 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:33 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=J&ppe=1&pw=1&scenario=4
@@ -3326,25 +3249,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:30 GMT
+      - Wed, 20 Apr 2022 11:54:33 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2162.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:30 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:33 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=J&ppe=1&pw=1&scenario=4
@@ -3364,25 +3287,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:30 GMT
+      - Wed, 20 Apr 2022 11:54:34 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":21772.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:30 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:34 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=3&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=K&ppe=1&pw=1&scenario=4
@@ -3402,7 +3325,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:30 GMT
+      - Wed, 20 Apr 2022 11:54:34 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -3410,17 +3333,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2162.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:30 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:34 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=40&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=K&ppe=1&pw=1&scenario=4
@@ -3440,7 +3363,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:30 GMT
+      - Wed, 20 Apr 2022 11:54:34 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -3448,17 +3371,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":21772.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:30 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:34 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=9999&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -3478,7 +3401,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:30 GMT
+      - Wed, 20 Apr 2022 11:54:35 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -3486,17 +3409,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2859897.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:30 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:35 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=10000&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -3516,17 +3439,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:30 GMT
+      - Wed, 20 Apr 2022 11:54:35 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '20'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -3534,7 +3457,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":2859897.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:30 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:35 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=0&pw=1&scenario=4
@@ -3554,17 +3477,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:31 GMT
+      - Wed, 20 Apr 2022 11:54:35 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -3572,7 +3495,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":2856.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:31 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:35 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=50&pw=1&scenario=4
@@ -3592,7 +3515,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:31 GMT
+      - Wed, 20 Apr 2022 11:54:35 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -3600,17 +3523,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2856.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:31 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:35 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=51&pw=1&scenario=4
@@ -3630,7 +3553,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:31 GMT
+      - Wed, 20 Apr 2022 11:54:36 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -3638,17 +3561,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2857.63}'
-  recorded_at: Wed, 03 Feb 2021 16:19:31 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:36 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=100&pw=1&scenario=4
@@ -3668,7 +3591,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:31 GMT
+      - Wed, 20 Apr 2022 11:54:36 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -3676,17 +3599,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2937.5}'
-  recorded_at: Wed, 03 Feb 2021 16:19:31 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:36 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=10000&pw=1&scenario=4
@@ -3706,17 +3629,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:31 GMT
+      - Wed, 20 Apr 2022 11:54:36 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -3724,7 +3647,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":19074.5}'
-  recorded_at: Wed, 03 Feb 2021 16:19:31 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:36 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=10001&pw=1&scenario=4
@@ -3744,7 +3667,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:32 GMT
+      - Wed, 20 Apr 2022 11:54:37 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -3752,17 +3675,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":19074.5}'
-  recorded_at: Wed, 03 Feb 2021 16:19:32 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:37 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=0&pw=1&scenario=4
@@ -3782,17 +3705,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:32 GMT
+      - Wed, 20 Apr 2022 11:54:37 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -3800,7 +3723,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":2142.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:32 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:37 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=50&pw=1&scenario=4
@@ -3820,7 +3743,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:32 GMT
+      - Wed, 20 Apr 2022 11:54:37 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -3828,17 +3751,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2142.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:32 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:37 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=51&pw=1&scenario=4
@@ -3858,17 +3781,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:32 GMT
+      - Wed, 20 Apr 2022 11:54:37 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -3876,7 +3799,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":2143.23}'
-  recorded_at: Wed, 03 Feb 2021 16:19:32 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:38 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=100&pw=1&scenario=4
@@ -3896,17 +3819,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:32 GMT
+      - Wed, 20 Apr 2022 11:54:38 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -3914,7 +3837,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":2203.5}'
-  recorded_at: Wed, 03 Feb 2021 16:19:32 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:38 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=10000&pw=1&scenario=4
@@ -3934,25 +3857,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:32 GMT
+      - Wed, 20 Apr 2022 11:54:38 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":14380.5}'
-  recorded_at: Wed, 03 Feb 2021 16:19:32 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:38 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=10001&pw=1&scenario=4
@@ -3972,7 +3895,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:33 GMT
+      - Wed, 20 Apr 2022 11:54:39 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -3980,17 +3903,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":14380.5}'
-  recorded_at: Wed, 03 Feb 2021 16:19:33 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:39 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=0&pw=1&scenario=4
@@ -4010,7 +3933,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:33 GMT
+      - Wed, 20 Apr 2022 11:54:39 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -4018,17 +3941,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1632.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:33 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:39 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=50&pw=1&scenario=4
@@ -4048,7 +3971,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:33 GMT
+      - Wed, 20 Apr 2022 11:54:39 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -4056,17 +3979,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1632.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:33 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:39 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=51&pw=1&scenario=4
@@ -4086,7 +4009,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:33 GMT
+      - Wed, 20 Apr 2022 11:54:39 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -4094,17 +4017,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1632.81}'
-  recorded_at: Wed, 03 Feb 2021 16:19:33 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:39 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=100&pw=1&scenario=4
@@ -4124,25 +4047,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:33 GMT
+      - Wed, 20 Apr 2022 11:54:40 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1672.5}'
-  recorded_at: Wed, 03 Feb 2021 16:19:33 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:40 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=10000&pw=1&scenario=4
@@ -4162,25 +4085,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:34 GMT
+      - Wed, 20 Apr 2022 11:54:40 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":9691.5}'
-  recorded_at: Wed, 03 Feb 2021 16:19:34 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:40 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=10001&pw=1&scenario=4
@@ -4200,17 +4123,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:34 GMT
+      - Wed, 20 Apr 2022 11:54:40 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -4218,7 +4141,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":9691.5}'
-  recorded_at: Wed, 03 Feb 2021 16:19:34 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:40 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=0&pw=1&scenario=4
@@ -4238,17 +4161,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:34 GMT
+      - Wed, 20 Apr 2022 11:54:41 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -4256,7 +4179,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1632.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:34 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:41 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=50&pw=1&scenario=4
@@ -4276,25 +4199,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:34 GMT
+      - Wed, 20 Apr 2022 11:54:41 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1632.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:34 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:41 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=51&pw=1&scenario=4
@@ -4314,7 +4237,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:34 GMT
+      - Wed, 20 Apr 2022 11:54:41 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -4322,17 +4245,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1632.98}'
-  recorded_at: Wed, 03 Feb 2021 16:19:35 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:41 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=100&pw=1&scenario=4
@@ -4352,25 +4275,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:35 GMT
+      - Wed, 20 Apr 2022 11:54:41 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1681.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:35 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:41 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=10000&pw=1&scenario=4
@@ -4390,25 +4313,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:35 GMT
+      - Wed, 20 Apr 2022 11:54:42 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":11383.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:35 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:42 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=10001&pw=1&scenario=4
@@ -4428,7 +4351,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:35 GMT
+      - Wed, 20 Apr 2022 11:54:42 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -4436,17 +4359,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":11383.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:35 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:42 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=0&scenario=4
@@ -4466,17 +4389,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:35 GMT
+      - Wed, 20 Apr 2022 11:54:42 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -4484,7 +4407,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":2856.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:35 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:42 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=10&scenario=4
@@ -4504,7 +4427,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:36 GMT
+      - Wed, 20 Apr 2022 11:54:43 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -4512,17 +4435,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2856.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:36 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:43 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=11&scenario=4
@@ -4542,17 +4465,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:36 GMT
+      - Wed, 20 Apr 2022 11:54:43 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -4560,7 +4483,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":2862.53}'
-  recorded_at: Wed, 03 Feb 2021 16:19:36 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:43 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=100&scenario=4
@@ -4580,25 +4503,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:36 GMT
+      - Wed, 20 Apr 2022 11:54:43 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":3443.7}'
-  recorded_at: Wed, 03 Feb 2021 16:19:36 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:43 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=QC&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1000&scenario=4
@@ -4618,7 +4541,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:36 GMT
+      - Wed, 20 Apr 2022 11:54:43 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -4626,17 +4549,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":9320.7}'
-  recorded_at: Wed, 03 Feb 2021 16:19:36 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:43 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=0&scenario=4
@@ -4656,17 +4579,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:36 GMT
+      - Wed, 20 Apr 2022 11:54:44 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -4674,7 +4597,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":2142.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:36 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:44 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=10&scenario=4
@@ -4694,17 +4617,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:37 GMT
+      - Wed, 20 Apr 2022 11:54:44 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -4712,7 +4635,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":2142.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:37 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:44 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=11&scenario=4
@@ -4732,17 +4655,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:37 GMT
+      - Wed, 20 Apr 2022 11:54:44 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -4750,7 +4673,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":2146.9}'
-  recorded_at: Wed, 03 Feb 2021 16:19:37 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:44 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=100&scenario=4
@@ -4770,25 +4693,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:37 GMT
+      - Wed, 20 Apr 2022 11:54:44 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2583.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:37 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:44 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEADJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1000&scenario=4
@@ -4808,17 +4731,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:37 GMT
+      - Wed, 20 Apr 2022 11:54:45 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -4826,7 +4749,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":6993.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:37 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:45 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=0&scenario=4
@@ -4846,17 +4769,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:37 GMT
+      - Wed, 20 Apr 2022 11:54:45 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -4864,7 +4787,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1632.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:37 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:45 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=10&scenario=4
@@ -4884,17 +4807,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:38 GMT
+      - Wed, 20 Apr 2022 11:54:45 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -4902,7 +4825,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1632.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:38 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:45 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=11&scenario=4
@@ -4922,17 +4845,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:38 GMT
+      - Wed, 20 Apr 2022 11:54:45 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -4940,7 +4863,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1635.26}'
-  recorded_at: Wed, 03 Feb 2021 16:19:38 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:45 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=100&scenario=4
@@ -4960,25 +4883,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:38 GMT
+      - Wed, 20 Apr 2022 11:54:46 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1925.4}'
-  recorded_at: Wed, 03 Feb 2021 16:19:38 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:46 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=LEDJR&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1000&scenario=4
@@ -4998,25 +4921,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:38 GMT
+      - Wed, 20 Apr 2022 11:54:46 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":4859.4}'
-  recorded_at: Wed, 03 Feb 2021 16:19:38 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:46 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=0&scenario=4
@@ -5036,7 +4959,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:38 GMT
+      - Wed, 20 Apr 2022 11:54:46 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -5044,17 +4967,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1632.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:38 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:46 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=10&scenario=4
@@ -5074,17 +4997,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:39 GMT
+      - Wed, 20 Apr 2022 11:54:46 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -5092,7 +5015,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1632.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:39 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:46 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=11&scenario=4
@@ -5112,7 +5035,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:39 GMT
+      - Wed, 20 Apr 2022 11:54:47 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -5120,17 +5043,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1636.9}'
-  recorded_at: Wed, 03 Feb 2021 16:19:39 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:47 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=100&scenario=4
@@ -5150,25 +5073,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:39 GMT
+      - Wed, 20 Apr 2022 11:54:47 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2073.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:39 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:47 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1000&scenario=4
@@ -5188,17 +5111,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:39 GMT
+      - Wed, 20 Apr 2022 11:54:47 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -5206,7 +5129,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":6483.0}'
-  recorded_at: Wed, 03 Feb 2021 16:19:39 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:47 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=2&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5226,7 +5149,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:39 GMT
+      - Wed, 20 Apr 2022 11:54:48 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -5234,17 +5157,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1958.4}'
-  recorded_at: Wed, 03 Feb 2021 16:19:39 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:48 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=3&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5264,17 +5187,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:40 GMT
+      - Wed, 20 Apr 2022 11:54:48 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -5282,7 +5205,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":2284.8}'
-  recorded_at: Wed, 03 Feb 2021 16:19:40 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:48 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=5&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5302,25 +5225,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:40 GMT
+      - Wed, 20 Apr 2022 11:54:48 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2937.6}'
-  recorded_at: Wed, 03 Feb 2021 16:19:40 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:48 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=10&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5340,7 +5263,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:40 GMT
+      - Wed, 20 Apr 2022 11:54:48 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -5348,17 +5271,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":4569.6}'
-  recorded_at: Wed, 03 Feb 2021 16:19:40 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:48 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=100&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5378,25 +5301,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:40 GMT
+      - Wed, 20 Apr 2022 11:54:49 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":33945.6}'
-  recorded_at: Wed, 03 Feb 2021 16:19:40 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:49 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=10000&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5416,17 +5339,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:40 GMT
+      - Wed, 20 Apr 2022 11:54:49 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '20'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -5434,7 +5357,45 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":3265305.6}'
-  recorded_at: Wed, 03 Feb 2021 16:19:40 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:49 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&pw=1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:54:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '17'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"amount":1632.0}'
+  recorded_at: Wed, 20 Apr 2022 11:54:49 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=2&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5454,25 +5415,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:41 GMT
+      - Wed, 20 Apr 2022 11:54:49 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1958.4}'
-  recorded_at: Wed, 03 Feb 2021 16:19:41 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:49 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=3&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5492,25 +5453,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:41 GMT
+      - Wed, 20 Apr 2022 11:54:50 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2284.8}'
-  recorded_at: Wed, 03 Feb 2021 16:19:41 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:50 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=5&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5530,25 +5491,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:41 GMT
+      - Wed, 20 Apr 2022 11:54:50 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":2937.6}'
-  recorded_at: Wed, 03 Feb 2021 16:19:41 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:50 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=10&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5568,7 +5529,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:41 GMT
+      - Wed, 20 Apr 2022 11:54:50 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -5576,17 +5537,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":4569.6}'
-  recorded_at: Wed, 03 Feb 2021 16:19:41 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:50 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=100&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5606,17 +5567,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:42 GMT
+      - Wed, 20 Apr 2022 11:54:50 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -5624,7 +5585,46 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":33945.6}'
-  recorded_at: Wed, 03 Feb 2021 16:19:42 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:50 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/?case_date=2018-01-01&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:54:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '158'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
+        Fee Scheme 9"}]}'
+  recorded_at: Wed, 20 Apr 2022 11:54:51 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/calculate/?advocate_type=JRALONE&day=1&fee_type_code=AGFS_FEE&number_of_cases=1&number_of_defendants=10000&offence_class=A&ppe=1&pw=1&scenario=4
@@ -5644,140 +5644,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:42 GMT
+      - Wed, 20 Apr 2022 11:54:51 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '20'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":3265305.6}'
-  recorded_at: Wed, 03 Feb 2021 16:19:42 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/?case_date=2018-01-01&type=LGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:19:43 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '156'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Allow:
-      - GET, HEAD, OPTIONS
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
-        Fee Scheme 2016-04"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:43 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=80&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:19:43 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '18'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Allow:
-      - GET
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"amount":1467.58}'
-  recorded_at: Wed, 03 Feb 2021 16:19:43 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=2&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=80&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:19:43 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '18'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Allow:
-      - GET
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"amount":1467.58}'
-  recorded_at: Wed, 03 Feb 2021 16:19:43 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:51 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=3&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=80&scenario=4
@@ -5797,17 +5682,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:44 GMT
+      - Wed, 20 Apr 2022 11:54:53 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -5815,7 +5700,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1720.12}'
-  recorded_at: Wed, 03 Feb 2021 16:19:44 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:53 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=200&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=80&scenario=4
@@ -5835,25 +5720,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:44 GMT
+      - Wed, 20 Apr 2022 11:54:54 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '19'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":90159.18}'
-  recorded_at: Wed, 03 Feb 2021 16:19:44 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:54 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=201&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=80&scenario=4
@@ -5873,25 +5758,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:45 GMT
+      - Wed, 20 Apr 2022 11:54:54 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '19'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":90159.18}'
-  recorded_at: Wed, 03 Feb 2021 16:19:45 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:54 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=2&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=0&scenario=4
@@ -5911,7 +5796,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:45 GMT
+      - Wed, 20 Apr 2022 11:54:55 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -5919,17 +5804,55 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1467.58}'
-  recorded_at: Wed, 03 Feb 2021 16:19:45 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:55 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=2&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=80&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:54:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '18'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"amount":1467.58}'
+  recorded_at: Wed, 20 Apr 2022 11:54:55 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=2&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=81&scenario=4
@@ -5949,7 +5872,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:46 GMT
+      - Wed, 20 Apr 2022 11:54:56 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -5957,17 +5880,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1484.16}'
-  recorded_at: Wed, 03 Feb 2021 16:19:46 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:56 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=3&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=0&scenario=4
@@ -5987,17 +5910,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:46 GMT
+      - Wed, 20 Apr 2022 11:54:56 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -6005,7 +5928,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1720.12}'
-  recorded_at: Wed, 03 Feb 2021 16:19:46 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:56 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=3&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=1&scenario=4
@@ -6025,25 +5948,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:46 GMT
+      - Wed, 20 Apr 2022 11:54:57 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1720.12}'
-  recorded_at: Wed, 03 Feb 2021 16:19:46 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:57 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=3&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=95&scenario=4
@@ -6063,7 +5986,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:46 GMT
+      - Wed, 20 Apr 2022 11:54:57 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -6071,17 +5994,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1720.12}'
-  recorded_at: Wed, 03 Feb 2021 16:19:46 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:57 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=3&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=96&scenario=4
@@ -6101,17 +6024,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:47 GMT
+      - Wed, 20 Apr 2022 11:54:58 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -6119,7 +6042,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1732.86}'
-  recorded_at: Wed, 03 Feb 2021 16:19:47 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:58 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=0&scenario=4
@@ -6139,25 +6062,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:47 GMT
+      - Wed, 20 Apr 2022 11:54:58 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1097.66}'
-  recorded_at: Wed, 03 Feb 2021 16:19:47 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:58 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=70&scenario=4
@@ -6177,7 +6100,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:47 GMT
+      - Wed, 20 Apr 2022 11:54:59 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -6185,17 +6108,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1097.66}'
-  recorded_at: Wed, 03 Feb 2021 16:19:47 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:59 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=B&ppe=71&scenario=4
@@ -6215,7 +6138,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:48 GMT
+      - Wed, 20 Apr 2022 11:54:59 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -6223,17 +6146,55 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1110.47}'
-  recorded_at: Wed, 03 Feb 2021 16:19:48 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:59 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=1&offence_class=A&ppe=80&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:55:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '18'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"amount":1467.58}'
+  recorded_at: Wed, 20 Apr 2022 11:55:00 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=2&offence_class=A&ppe=80&scenario=4
@@ -6253,25 +6214,25 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:48 GMT
+      - Wed, 20 Apr 2022 11:55:00 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1761.1}'
-  recorded_at: Wed, 03 Feb 2021 16:19:48 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:00 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=3&offence_class=A&ppe=80&scenario=4
@@ -6291,7 +6252,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:48 GMT
+      - Wed, 20 Apr 2022 11:55:00 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -6299,17 +6260,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1761.1}'
-  recorded_at: Wed, 03 Feb 2021 16:19:48 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:00 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=4&offence_class=A&ppe=80&scenario=4
@@ -6329,17 +6290,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:49 GMT
+      - Wed, 20 Apr 2022 11:55:01 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -6347,7 +6308,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1761.1}'
-  recorded_at: Wed, 03 Feb 2021 16:19:49 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:01 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=5&offence_class=A&ppe=80&scenario=4
@@ -6367,7 +6328,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:49 GMT
+      - Wed, 20 Apr 2022 11:55:01 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -6375,17 +6336,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"amount":1907.85}'
-  recorded_at: Wed, 03 Feb 2021 16:19:49 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:01 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=10&offence_class=A&ppe=80&scenario=4
@@ -6405,17 +6366,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:49 GMT
+      - Wed, 20 Apr 2022 11:55:01 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -6423,7 +6384,46 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1907.85}'
-  recorded_at: Wed, 03 Feb 2021 16:19:49 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:01 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/?case_date=2018-01-01&type=LGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:55:01 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
+        Fee Scheme 2016-04"}]}'
+  recorded_at: Wed, 20 Apr 2022 11:55:02 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/2/calculate/?day=1&fee_type_code=LIT_FEE&number_of_cases=1&number_of_defendants=100&offence_class=A&ppe=80&scenario=4
@@ -6443,17 +6443,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:50 GMT
+      - Wed, 20 Apr 2022 11:55:02 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '18'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -6461,5 +6461,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1907.85}'
-  recorded_at: Wed, 03 Feb 2021 16:19:50 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:02 GMT
 recorded_with: VCR 6.0.0

--- a/spec/vcr/modifier_types_spec.yml
+++ b/spec/vcr/modifier_types_spec.yml
@@ -2,45 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:19:53 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '106'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Allow:
-      - GET, HEAD, OPTIONS
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
-        Fee Scheme 9"}'
-  recorded_at: Wed, 03 Feb 2021 16:19:53 GMT
-- request:
-    method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/modifier-types/
     body:
       encoding: US-ASCII
@@ -58,19 +19,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:53 GMT
+      - Wed, 20 Apr 2022 11:55:08 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '594'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -82,7 +43,7 @@ http_interactions:
         of prosecuting evidence","unit":"PPE"},{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
         months between trials","unit":"MONTH"},{"id":6,"name":"THIRD_CRACKED","description":"Third
         in which a trial cracked","unit":"THIRD"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:53 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:08 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/modifier-types/1/
@@ -102,17 +63,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:53 GMT
+      - Wed, 20 Apr 2022 11:55:09 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '79'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -120,7 +81,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"id":1,"name":"NUMBER_OF_CASES","description":"Number of cases","unit":"CASE"}'
-  recorded_at: Wed, 03 Feb 2021 16:19:53 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:09 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/modifier-types/?scenario=1
@@ -140,19 +101,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:53 GMT
+      - Wed, 20 Apr 2022 11:55:09 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '406'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -162,7 +123,7 @@ http_interactions:
         of defendants","unit":"DEFENDANT"},{"id":3,"name":"TRIAL_LENGTH","description":"Trial
         length","unit":"DAY"},{"id":4,"name":"PAGES_OF_PROSECUTING_EVIDENCE","description":"Pages
         of prosecuting evidence","unit":"PPE"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:53 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:09 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/modifier-types/?advocate_type=QC
@@ -182,7 +143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:53 GMT
+      - Wed, 20 Apr 2022 11:55:09 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -190,11 +151,11 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -206,7 +167,7 @@ http_interactions:
         of prosecuting evidence","unit":"PPE"},{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
         months between trials","unit":"MONTH"},{"id":6,"name":"THIRD_CRACKED","description":"Third
         in which a trial cracked","unit":"THIRD"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:53 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:09 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/modifier-types/?offence_class=A
@@ -226,7 +187,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:53 GMT
+      - Wed, 20 Apr 2022 11:55:09 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -234,11 +195,11 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -250,7 +211,7 @@ http_interactions:
         of prosecuting evidence","unit":"PPE"},{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
         months between trials","unit":"MONTH"},{"id":6,"name":"THIRD_CRACKED","description":"Third
         in which a trial cracked","unit":"THIRD"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:53 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:09 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/modifier-types/?fee_type_code=AGFS_FEE
@@ -270,19 +231,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:54 GMT
+      - Wed, 20 Apr 2022 11:55:09 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '521'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -293,7 +254,7 @@ http_interactions:
         of prosecuting evidence","unit":"PPE"},{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
         months between trials","unit":"MONTH"},{"id":6,"name":"THIRD_CRACKED","description":"Third
         in which a trial cracked","unit":"THIRD"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:54 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:09 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/modifier-types/1001/
@@ -313,7 +274,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:54 GMT
+      - Wed, 20 Apr 2022 11:55:09 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -321,17 +282,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
-  recorded_at: Wed, 03 Feb 2021 16:19:54 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:09 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/modifier-types/?fee_type_code=INVALID_CODE
@@ -351,7 +312,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:54 GMT
+      - Wed, 20 Apr 2022 11:55:09 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -359,17 +320,56 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '["''INVALID_CODE'' is not a valid `fee_type_code`"]'
-  recorded_at: Wed, 03 Feb 2021 16:19:54 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:09 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:55:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '106'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
+        Fee Scheme 9"}'
+  recorded_at: Wed, 20 Apr 2022 11:55:09 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/modifier-types/?fee_type_code=AGFS_APPEAL_CON&scenario=5
@@ -389,19 +389,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:54 GMT
+      - Wed, 20 Apr 2022 11:55:09 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '226'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -409,5 +409,5 @@ http_interactions:
       string: '{"count":2,"next":null,"previous":null,"results":[{"id":1,"name":"NUMBER_OF_CASES","description":"Number
         of cases","unit":"CASE"},{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:54 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:09 GMT
 recorded_with: VCR 6.0.0

--- a/spec/vcr/offence_classes_spec.yml
+++ b/spec/vcr/offence_classes_spec.yml
@@ -2,45 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:19:54 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '106'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Allow:
-      - GET, HEAD, OPTIONS
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
-        Fee Scheme 9"}'
-  recorded_at: Wed, 03 Feb 2021 16:19:54 GMT
-- request:
-    method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/offence-classes/
     body:
       encoding: US-ASCII
@@ -58,17 +19,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:54 GMT
+      - Wed, 20 Apr 2022 11:55:10 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '929'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -86,7 +47,7 @@ http_interactions:
         justice and similar offences"},{"id":"J","name":"J","description":"Serious
         sexual offences"},{"id":"K","name":"K","description":"Other offences of dishonesty
         (high value)"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:54 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:10 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/offence-classes/A/
@@ -106,17 +67,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:54 GMT
+      - Wed, 20 Apr 2022 11:55:11 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '73'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -124,7 +85,46 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"id":"A","name":"A","description":"Homicide and related grave offences"}'
-  recorded_at: Wed, 03 Feb 2021 16:19:54 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:11 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:55:11 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '106'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
+        Fee Scheme 9"}'
+  recorded_at: Wed, 20 Apr 2022 11:55:11 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/offence-classes/INVALID/
@@ -144,7 +144,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:54 GMT
+      - Wed, 20 Apr 2022 11:55:11 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -152,15 +152,15 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
-  recorded_at: Wed, 03 Feb 2021 16:19:54 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:11 GMT
 recorded_with: VCR 6.0.0

--- a/spec/vcr/prices_spec.yml
+++ b/spec/vcr/prices_spec.yml
@@ -2,187 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:19:54 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '106'
-      Connection:
-      - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
-      Allow:
-      - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
-        Fee Scheme 9"}'
-  recorded_at: Wed, 03 Feb 2021 16:19:54 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/prices/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:19:54 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '46844'
-      Connection:
-      - keep-alive
-      Allow:
-      - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"count":2890,"next":"https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/prices/?page=2","previous":null,"results":[{"id":1,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":3,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"979.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":4,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"979.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":5,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":6,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":7,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":8,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":9,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2529.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":10,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2529.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":11,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"857.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":12,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"857.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":13,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":14,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":15,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":16,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":17,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1968.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":18,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1968.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":19,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"816.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":20,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"816.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":21,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":22,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":23,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":24,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":25,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"D","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2284.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":26,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"D","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2284.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":27,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"D","scheme":1,"unit":"DAY","fee_per_unit":"816.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":28,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"D","scheme":1,"unit":"DAY","fee_per_unit":"816.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":29,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"D","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":30,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"D","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":31,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"D","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":32,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"D","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":33,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"E","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1514.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":34,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"E","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1514.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":35,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"E","scheme":1,"unit":"DAY","fee_per_unit":"612.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":36,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"E","scheme":1,"unit":"DAY","fee_per_unit":"612.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":37,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"E","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":38,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"E","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":39,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"E","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":40,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"E","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":41,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"F","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1514.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":42,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"F","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1514.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":43,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"F","scheme":1,"unit":"DAY","fee_per_unit":"612.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":44,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"F","scheme":1,"unit":"DAY","fee_per_unit":"612.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":45,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"F","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":46,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"F","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":47,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"F","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":48,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"F","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":49,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"G","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1514.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":50,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"G","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1514.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":51,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"G","scheme":1,"unit":"DAY","fee_per_unit":"612.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":52,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"G","scheme":1,"unit":"DAY","fee_per_unit":"612.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":53,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"G","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":54,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"G","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":55,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"G","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":56,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"G","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":57,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"H","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1903.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":58,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"H","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1903.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":59,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"H","scheme":1,"unit":"DAY","fee_per_unit":"816.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":60,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"H","scheme":1,"unit":"DAY","fee_per_unit":"816.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":61,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"H","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":62,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"H","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":63,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"H","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":64,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"H","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":65,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"I","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2122.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":66,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"I","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2122.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":67,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"I","scheme":1,"unit":"DAY","fee_per_unit":"816.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":68,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"I","scheme":1,"unit":"DAY","fee_per_unit":"816.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":69,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"I","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":70,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"I","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":71,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"I","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":72,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"I","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":73,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"J","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":74,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"J","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":75,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"J","scheme":1,"unit":"DAY","fee_per_unit":"979.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":76,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"J","scheme":1,"unit":"DAY","fee_per_unit":"979.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":77,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"J","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":78,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"J","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":79,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"J","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":80,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"J","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":81,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"K","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":82,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"K","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":83,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"K","scheme":1,"unit":"DAY","fee_per_unit":"979.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":84,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"K","scheme":1,"unit":"DAY","fee_per_unit":"979.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":85,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"K","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":86,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"K","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":87,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"K","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":88,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"K","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":89,"scenario":4,"advocate_type":"LEADJR","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2142.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":90,"scenario":11,"advocate_type":"LEADJR","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2142.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":91,"scenario":4,"advocate_type":"LEADJR","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"734.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":92,"scenario":11,"advocate_type":"LEADJR","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"734.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":93,"scenario":4,"advocate_type":"LEADJR","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"331.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":94,"scenario":11,"advocate_type":"LEADJR","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"331.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":95,"scenario":4,"advocate_type":"LEADJR","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"356.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":96,"scenario":11,"advocate_type":"LEADJR","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"356.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":97,"scenario":4,"advocate_type":"LEADJR","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1897.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":98,"scenario":11,"advocate_type":"LEADJR","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1897.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":99,"scenario":4,"advocate_type":"LEADJR","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"643.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":100,"scenario":11,"advocate_type":"LEADJR","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"643.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
-        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:55 GMT
-- request:
-    method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/prices/1/
     body:
       encoding: US-ASCII
@@ -200,17 +19,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:55 GMT
+      - Wed, 20 Apr 2022 11:55:16 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '688'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -220,7 +39,7 @@ http_interactions:
       string: '{"id":1,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}'
-  recorded_at: Wed, 03 Feb 2021 16:19:55 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:16 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/prices/?scenario=5
@@ -240,7 +59,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:55 GMT
+      - Wed, 20 Apr 2022 11:55:16 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -248,11 +67,11 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -338,7 +157,7 @@ http_interactions:
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":3141,"scenario":5,"advocate_type":"LEADJR","fee_type":32,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"346.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":3142,"scenario":5,"advocate_type":"JRALONE","fee_type":32,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"238.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":3162,"scenario":5,"advocate_type":"QC","fee_type":33,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"74.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":3167,"scenario":5,"advocate_type":"LEDJR","fee_type":33,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"39.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":3176,"scenario":5,"advocate_type":"LEADJR","fee_type":33,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"56.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false},{"id":3189,"scenario":5,"advocate_type":"JRALONE","fee_type":33,"offence_class":null,"scheme":1,"unit":"HOUR","fee_per_unit":"39.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:55 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:16 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/prices/?advocate_type=QC
@@ -358,17 +177,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:55 GMT
+      - Wed, 20 Apr 2022 11:55:17 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '54471'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -512,7 +331,7 @@ http_interactions:
         months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-25.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
         months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":1,"fixed_percent":"0.00","percent_per_unit":"0.00","modifier_type":{"id":6,"name":"THIRD_CRACKED","description":"Third
         in which a trial cracked","unit":"THIRD"},"required":true,"priority":0,"strict_range":true}],"strict_range":false}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:55 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:17 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/prices/?offence_class=A
@@ -532,19 +351,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:56 GMT
+      - Wed, 20 Apr 2022 11:55:17 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '69265'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -746,7 +565,7 @@ http_interactions:
         months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-25.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
         months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":1,"fixed_percent":"0.00","percent_per_unit":"0.00","modifier_type":{"id":6,"name":"THIRD_CRACKED","description":"Third
         in which a trial cracked","unit":"THIRD"},"required":true,"priority":0,"strict_range":true}],"strict_range":false}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:56 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:17 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/prices/?fee_type_code=AGFS_FEE
@@ -766,19 +585,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:56 GMT
+      - Wed, 20 Apr 2022 11:55:17 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '46867'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -888,7 +707,7 @@ http_interactions:
         months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":99,"scenario":4,"advocate_type":"LEADJR","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"643.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":100,"scenario":11,"advocate_type":"LEADJR","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"643.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
         months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
         months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:56 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:17 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/prices/-1/
@@ -908,25 +727,167 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:56 GMT
+      - Wed, 20 Apr 2022 11:55:18 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '23'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
-  recorded_at: Wed, 03 Feb 2021 16:19:56 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:18 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/prices/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:55:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '46844'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"count":2890,"next":"https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/prices/?page=2","previous":null,"results":[{"id":1,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":3,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"979.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":4,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"979.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":5,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":6,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":7,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":8,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":9,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2529.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":10,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2529.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":11,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"857.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":12,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"857.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":13,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":14,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":15,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":16,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":17,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1968.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":18,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1968.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":19,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"816.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":20,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"816.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":21,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":22,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":23,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":24,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":25,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"D","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2284.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":26,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"D","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2284.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":27,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"D","scheme":1,"unit":"DAY","fee_per_unit":"816.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":28,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"D","scheme":1,"unit":"DAY","fee_per_unit":"816.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":29,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"D","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":30,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"D","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":31,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"D","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":32,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"D","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":33,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"E","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1514.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":34,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"E","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1514.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":35,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"E","scheme":1,"unit":"DAY","fee_per_unit":"612.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":36,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"E","scheme":1,"unit":"DAY","fee_per_unit":"612.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":37,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"E","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":38,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"E","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":39,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"E","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":40,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"E","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":41,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"F","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1514.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":42,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"F","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1514.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":43,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"F","scheme":1,"unit":"DAY","fee_per_unit":"612.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":44,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"F","scheme":1,"unit":"DAY","fee_per_unit":"612.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":45,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"F","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":46,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"F","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":47,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"F","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":48,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"F","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":49,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"G","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1514.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":50,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"G","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1514.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":51,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"G","scheme":1,"unit":"DAY","fee_per_unit":"612.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":52,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"G","scheme":1,"unit":"DAY","fee_per_unit":"612.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":53,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"G","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":54,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"G","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":55,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"G","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":56,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"G","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":57,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"H","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1903.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":58,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"H","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1903.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":59,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"H","scheme":1,"unit":"DAY","fee_per_unit":"816.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":60,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"H","scheme":1,"unit":"DAY","fee_per_unit":"816.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":61,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"H","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":62,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"H","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":63,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"H","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":64,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"H","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":65,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"I","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2122.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":66,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"I","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2122.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":67,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"I","scheme":1,"unit":"DAY","fee_per_unit":"816.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":68,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"I","scheme":1,"unit":"DAY","fee_per_unit":"816.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":69,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"I","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":70,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"I","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":71,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"I","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":72,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"I","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":73,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"J","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":74,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"J","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":75,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"J","scheme":1,"unit":"DAY","fee_per_unit":"979.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":76,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"J","scheme":1,"unit":"DAY","fee_per_unit":"979.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":77,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"J","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":78,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"J","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":79,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"J","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":80,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"J","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":81,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"K","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":82,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"K","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2856.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":83,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"K","scheme":1,"unit":"DAY","fee_per_unit":"979.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":84,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"K","scheme":1,"unit":"DAY","fee_per_unit":"979.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":85,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"K","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":86,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"K","scheme":1,"unit":"DAY","fee_per_unit":"387.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":87,"scenario":4,"advocate_type":"QC","fee_type":34,"offence_class":"K","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":88,"scenario":11,"advocate_type":"QC","fee_type":34,"offence_class":"K","scheme":1,"unit":"DAY","fee_per_unit":"414.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":89,"scenario":4,"advocate_type":"LEADJR","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2142.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":90,"scenario":11,"advocate_type":"LEADJR","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"2142.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":91,"scenario":4,"advocate_type":"LEADJR","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"734.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":92,"scenario":11,"advocate_type":"LEADJR","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"734.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":93,"scenario":4,"advocate_type":"LEADJR","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"331.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":94,"scenario":11,"advocate_type":"LEADJR","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"331.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":95,"scenario":4,"advocate_type":"LEADJR","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"356.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":96,"scenario":11,"advocate_type":"LEADJR","fee_type":34,"offence_class":"A","scheme":1,"unit":"DAY","fee_per_unit":"356.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":97,"scenario":4,"advocate_type":"LEADJR","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1897.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":98,"scenario":11,"advocate_type":"LEADJR","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1897.00000","limit_from":1,"limit_to":2,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false},{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":99,"scenario":4,"advocate_type":"LEADJR","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"643.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":100,"scenario":11,"advocate_type":"LEADJR","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"643.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
+        months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false}]}'
+  recorded_at: Wed, 20 Apr 2022 11:55:18 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/prices/?page=2
@@ -946,17 +907,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:21:14 GMT
+      - Wed, 20 Apr 2022 11:55:18 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '45445'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -1060,7 +1021,46 @@ http_interactions:
         months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":195,"scenario":4,"advocate_type":"LEDJR","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"408.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":196,"scenario":11,"advocate_type":"LEDJR","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"408.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
         months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
         months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":197,"scenario":4,"advocate_type":"LEDJR","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"221.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":198,"scenario":11,"advocate_type":"LEDJR","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"221.00000","fixed_fee":"0.00000","limit_from":41,"limit_to":50,"modifiers":[],"strict_range":false},{"id":199,"scenario":4,"advocate_type":"LEDJR","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"237.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false},{"id":200,"scenario":11,"advocate_type":"LEDJR","fee_type":34,"offence_class":"C","scheme":1,"unit":"DAY","fee_per_unit":"237.00000","fixed_fee":"0.00000","limit_from":51,"limit_to":9999,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Wed, 03 Feb 2021 16:21:14 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:18 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:55:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '106'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
+        Fee Scheme 9"}'
+  recorded_at: Wed, 20 Apr 2022 11:55:18 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/prices/?fee_type_code=AGFS_APPEAL_CON&scenario=5
@@ -1080,19 +1080,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:21:14 GMT
+      - Wed, 20 Apr 2022 11:55:18 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '2831'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -1106,5 +1106,5 @@ http_interactions:
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false},{"id":2064,"scenario":5,"advocate_type":"JRALONE","fee_type":8,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"130.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Wed, 03 Feb 2021 16:21:14 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:18 GMT
 recorded_with: VCR 6.0.0

--- a/spec/vcr/scenarios_spec.yml
+++ b/spec/vcr/scenarios_spec.yml
@@ -2,45 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:21:15 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '106'
-      Connection:
-      - keep-alive
-      Allow:
-      - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
-        Fee Scheme 9"}'
-  recorded_at: Wed, 03 Feb 2021 16:21:15 GMT
-- request:
-    method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/scenarios/
     body:
       encoding: US-ASCII
@@ -58,17 +19,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:21:15 GMT
+      - Wed, 20 Apr 2022 11:55:20 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '702'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -81,7 +42,7 @@ http_interactions:
         for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
         of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":12,"name":"Elected
         case not proceeded","code":"AS000014"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:21:15 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:20 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/scenarios/1/
@@ -101,17 +62,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:21:15 GMT
+      - Wed, 20 Apr 2022 11:55:20 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '50'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -119,7 +80,46 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"id":1,"name":"Discontinuance","code":"AS000001"}'
-  recorded_at: Wed, 03 Feb 2021 16:21:15 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:20 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:55:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '106'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
+        Fee Scheme 9"}'
+  recorded_at: Wed, 20 Apr 2022 11:55:20 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/scenarios/1001/
@@ -139,7 +139,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:21:15 GMT
+      - Wed, 20 Apr 2022 11:55:20 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -147,15 +147,15 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
-  recorded_at: Wed, 03 Feb 2021 16:21:15 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:20 GMT
 recorded_with: VCR 6.0.0

--- a/spec/vcr/searchable.yml
+++ b/spec/vcr/searchable.yml
@@ -2,45 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:19:16 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '106'
-      Connection:
-      - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
-      Allow:
-      - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
-        Fee Scheme 9"}'
-  recorded_at: Wed, 03 Feb 2021 16:19:16 GMT
-- request:
-    method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/advocate-types/
     body:
       encoding: US-ASCII
@@ -58,19 +19,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:16 GMT
+      - Wed, 20 Apr 2022 11:54:06 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '189'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -78,7 +39,7 @@ http_interactions:
       string: '{"count":4,"next":null,"previous":null,"results":[{"id":"JRALONE","name":"Junior
         alone"},{"id":"LEADJR","name":"Leading junior"},{"id":"LEDJR","name":"Led
         junior"},{"id":"QC","name":"QC"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:16 GMT
+  recorded_at: Wed, 20 Apr 2022 11:54:06 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/fee-types/
@@ -98,17 +59,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:53 GMT
+      - Wed, 20 Apr 2022 11:55:08 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '4205'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -152,7 +113,7 @@ http_interactions:
         (full day)","code":"AGFS_CONFISC_WL","is_basic":false,"aggregation":"sum"},{"id":90,"name":"Hearings
         relating to admissibility of evidence (half day)","code":"AGFS_ADM_EVD_HF","is_basic":false,"aggregation":"sum"},{"id":91,"name":"Wasted
         preparation fee","code":"AGFS_WSTD_PREP","is_basic":false,"aggregation":"sum"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:53 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:08 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/modifier-types/
@@ -172,17 +133,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:54 GMT
+      - Wed, 20 Apr 2022 11:55:10 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '594'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -196,7 +157,7 @@ http_interactions:
         of prosecuting evidence","unit":"PPE"},{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
         months between trials","unit":"MONTH"},{"id":6,"name":"THIRD_CRACKED","description":"Third
         in which a trial cracked","unit":"THIRD"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:54 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:10 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/offence-classes/
@@ -216,19 +177,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:19:54 GMT
+      - Wed, 20 Apr 2022 11:55:11 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '929'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -244,7 +205,7 @@ http_interactions:
         justice and similar offences"},{"id":"J","name":"J","description":"Serious
         sexual offences"},{"id":"K","name":"K","description":"Other offences of dishonesty
         (high value)"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:19:54 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:11 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/prices/
@@ -264,19 +225,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:21:14 GMT
+      - Wed, 20 Apr 2022 11:55:20 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '46844'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -386,7 +347,7 @@ http_interactions:
         months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false},{"id":99,"scenario":4,"advocate_type":"LEADJR","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"643.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[],"strict_range":false},{"id":100,"scenario":11,"advocate_type":"LEADJR","fee_type":34,"offence_class":"B","scheme":1,"unit":"DAY","fee_per_unit":"643.00000","fixed_fee":"0.00000","limit_from":3,"limit_to":40,"modifiers":[{"limit_from":0,"limit_to":0,"fixed_percent":"-30.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
         months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true},{"limit_from":1,"limit_to":null,"fixed_percent":"-20.00","percent_per_unit":"0.00","modifier_type":{"id":5,"name":"RETRIAL_INTERVAL","description":"Whole
         months between trials","unit":"MONTH"},"required":false,"priority":5,"strict_range":true}],"strict_range":false}]}'
-  recorded_at: Wed, 03 Feb 2021 16:21:14 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:20 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/scenarios/
@@ -406,19 +367,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:21:15 GMT
+      - Wed, 20 Apr 2022 11:55:21 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '702'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -429,7 +390,46 @@ http_interactions:
         for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
         of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":12,"name":"Elected
         case not proceeded","code":"AS000014"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:21:15 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:21 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:55:23 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '106'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
+        Fee Scheme 9"}'
+  recorded_at: Wed, 20 Apr 2022 11:55:23 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/units/
@@ -449,19 +449,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:21:16 GMT
+      - Wed, 20 Apr 2022 11:55:23 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '272'
       Connection:
       - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -469,5 +469,5 @@ http_interactions:
       string: '{"count":6,"next":null,"previous":null,"results":[{"id":"CASE","name":"Case"},{"id":"DAY","name":"Whole
         Days"},{"id":"HALFDAY","name":"Half Days"},{"id":"HOUR","name":"Hours"},{"id":"PPE","name":"Pages
         of Prosecuting Evidence"},{"id":"PW","name":"Prosecution Witnesses"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:21:16 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:23 GMT
 recorded_with: VCR 6.0.0

--- a/spec/vcr/units_spec.yml
+++ b/spec/vcr/units_spec.yml
@@ -2,85 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:21:15 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '106'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Allow:
-      - GET, HEAD, OPTIONS
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
-        Fee Scheme 9"}'
-  recorded_at: Wed, 03 Feb 2021 16:21:15 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/units/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/1.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Feb 2021 16:21:15 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '272'
-      Connection:
-      - keep-alive
-      Allow:
-      - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"count":6,"next":null,"previous":null,"results":[{"id":"CASE","name":"Case"},{"id":"DAY","name":"Whole
-        Days"},{"id":"HALFDAY","name":"Half Days"},{"id":"HOUR","name":"Hours"},{"id":"PPE","name":"Pages
-        of Prosecuting Evidence"},{"id":"PW","name":"Prosecution Witnesses"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:21:15 GMT
-- request:
-    method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/units/DAY/
     body:
       encoding: US-ASCII
@@ -98,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:21:15 GMT
+      - Wed, 20 Apr 2022 11:55:22 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -106,17 +27,17 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"id":"DAY","name":"Whole Days"}'
-  recorded_at: Wed, 03 Feb 2021 16:21:15 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:22 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/units/?scenario=1
@@ -136,7 +57,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:21:15 GMT
+      - Wed, 20 Apr 2022 11:55:22 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -144,11 +65,11 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -156,7 +77,7 @@ http_interactions:
       string: '{"count":5,"next":null,"previous":null,"results":[{"id":"CASE","name":"Case"},{"id":"DAY","name":"Whole
         Days"},{"id":"HALFDAY","name":"Half Days"},{"id":"HOUR","name":"Hours"},{"id":"PPE","name":"Pages
         of Prosecuting Evidence"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:21:15 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:22 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/units/?advocate_type=QC
@@ -176,7 +97,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:21:15 GMT
+      - Wed, 20 Apr 2022 11:55:22 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -184,11 +105,11 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -196,7 +117,7 @@ http_interactions:
       string: '{"count":6,"next":null,"previous":null,"results":[{"id":"CASE","name":"Case"},{"id":"DAY","name":"Whole
         Days"},{"id":"HALFDAY","name":"Half Days"},{"id":"HOUR","name":"Hours"},{"id":"PPE","name":"Pages
         of Prosecuting Evidence"},{"id":"PW","name":"Prosecution Witnesses"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:21:15 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:22 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/units/?offence_class=A
@@ -216,7 +137,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:21:15 GMT
+      - Wed, 20 Apr 2022 11:55:22 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -224,11 +145,11 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -236,7 +157,7 @@ http_interactions:
       string: '{"count":6,"next":null,"previous":null,"results":[{"id":"CASE","name":"Case"},{"id":"DAY","name":"Whole
         Days"},{"id":"HALFDAY","name":"Half Days"},{"id":"HOUR","name":"Hours"},{"id":"PPE","name":"Pages
         of Prosecuting Evidence"},{"id":"PW","name":"Prosecution Witnesses"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:21:15 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:22 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/units/?fee_type_code=AGFS_FEE
@@ -256,17 +177,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:21:16 GMT
+      - Wed, 20 Apr 2022 11:55:22 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '179'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -276,7 +197,7 @@ http_interactions:
       string: '{"count":3,"next":null,"previous":null,"results":[{"id":"DAY","name":"Whole
         Days"},{"id":"PPE","name":"Pages of Prosecuting Evidence"},{"id":"PW","name":"Prosecution
         Witnesses"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:21:16 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:22 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/units/1001/
@@ -296,7 +217,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:21:16 GMT
+      - Wed, 20 Apr 2022 11:55:22 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -304,17 +225,57 @@ http_interactions:
       Connection:
       - keep-alive
       Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"detail":"Not found."}'
-  recorded_at: Wed, 03 Feb 2021 16:21:16 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:22 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/units/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:55:22 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '272'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"count":6,"next":null,"previous":null,"results":[{"id":"CASE","name":"Case"},{"id":"DAY","name":"Whole
+        Days"},{"id":"HALFDAY","name":"Half Days"},{"id":"HOUR","name":"Hours"},{"id":"PPE","name":"Pages
+        of Prosecuting Evidence"},{"id":"PW","name":"Prosecution Witnesses"}]}'
+  recorded_at: Wed, 20 Apr 2022 11:55:22 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/units/?fee_type_code=INVALID_FEE_TYPE_CODE&scenario=5
@@ -334,17 +295,17 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:21:16 GMT
+      - Wed, 20 Apr 2022 11:55:22 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '58'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -352,7 +313,46 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '["''INVALID_FEE_TYPE_CODE'' is not a valid `fee_type_code`"]'
-  recorded_at: Wed, 03 Feb 2021 16:21:16 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:22 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Apr 2022 11:55:23 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '106'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
+        Fee Scheme 9"}'
+  recorded_at: Wed, 20 Apr 2022 11:55:23 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/1/units/?offence_class=E&scenario=5
@@ -372,17 +372,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Feb 2021 16:21:16 GMT
+      - Wed, 20 Apr 2022 11:55:23 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '177'
       Connection:
       - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
       Allow:
       - GET, HEAD, OPTIONS
-      Vary:
-      - Accept, Cookie
       X-Frame-Options:
       - SAMEORIGIN
       Strict-Transport-Security:
@@ -391,5 +391,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":4,"next":null,"previous":null,"results":[{"id":"CASE","name":"Case"},{"id":"DAY","name":"Whole
         Days"},{"id":"HALFDAY","name":"Half Days"},{"id":"HOUR","name":"Hours"}]}'
-  recorded_at: Wed, 03 Feb 2021 16:21:16 GMT
+  recorded_at: Wed, 20 Apr 2022 11:55:23 GMT
 recorded_with: VCR 6.0.0


### PR DESCRIPTION
#### What

Fix tests to work with Ruby 3

#### Ticket

[Review and update laa-fee-calculator-client gem](https://dsdmoj.atlassian.net/browse/CFP-395)

#### Why

CCCD is moving to Ruby 3+ so we want to ensure that this gem is compatible.

#### How

* Update VCR files
* Update some tests to use expanded keywords arguments
* Remove `pry-byebug` gem
* Update Github Actions for Ruby 3.0 and 3.1.