### PR TITLE
Prevent major version updates for faraday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
   open-pull-requests-limit: 10
   reviewers:
   - ministryofjustice/laa-claim-for-payment
+  ignore:
+  - dependency-name: faraday
+    update-types: version-update:semver-major


### PR DESCRIPTION
#### What

Prevent dependabot from updating major versions of `faraday`.

#### Ticket

N/A

#### Why

Faraday version 2.0 has breaking changes so an upgrade could have knock-on effects. Version 1.x of this gem should be fixed to `faraday` version `~> 1.0` and a new major release 2.x of this gem should be fixed to `faraday` version `~> 2.0`.

#### How

Add this to the dependabot configuration:

```yaml
  ignore:
  - dependency-name: faraday
    update-types: version-update:semver-major
```