### PR TITLE
Prepare 1.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,8 @@ Add latest change log entries at top using template:
 ### Removed
   -
 ```
-## Version UNRELEASED
-### Added
-  -
-### Fixed
-  -
-### Modified
-  -
+## Version 1.3.1
+
 ### Removed
   - `addressable` gem dependency
 

--- a/lib/laa/fee_calculator/version.rb
+++ b/lib/laa/fee_calculator/version.rb
@@ -2,7 +2,7 @@
 
 module LAA
   module FeeCalculator
-    VERSION = '1.3.0'
+    VERSION = '1.3.1'
     USER_AGENT = "laa-fee-calculator-client/#{VERSION}"
   end
 end


### PR DESCRIPTION
#### What

Update version number and change log for 1.3.1 release.

[Changes since 1.3.0;](https://github.com/ministryofjustice/laa-fee-calculator-client/compare/v1.3.0...master)

* Remove dependency on `addressable` gem
* Various Rubocop fixes
