### PR TITLE
Add options for caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Add latest change log entries at top using template:
 ### Removed
   -
 ```
+
+
+## Version 1.4.0
+
+### Added
+  - New configuration options for caching and logging
+
 ## Version 1.3.1
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -163,6 +163,17 @@ end
 
 ```
 
+## Caching
+
+Caching can be configured, with optional logging, by providing a cache store:
+
+```ruby
+LAA::FeeCalculator.configure do |config|
+  config.cache = Rails.cache
+  config.logger = Rails.logger
+end
+```
+
 Note: 
 
 ## Contributing

--- a/laa-fee-calculator-client.gemspec
+++ b/laa-fee-calculator-client.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6.0'
 
   spec.add_runtime_dependency 'faraday', '~> 1.0'
+  spec.add_runtime_dependency 'faraday-http-cache', '~> 2.2'
 
   spec.add_development_dependency 'awesome_print'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/lib/laa/fee_calculator/configuration.rb
+++ b/lib/laa/fee_calculator/configuration.rb
@@ -6,7 +6,7 @@ module LAA
       LAA_FEE_CALCULATOR_API_V1 = 'https://laa-fee-calculator.service.justice.gov.uk/api/v1'
       HEADERS = { 'Accept' => 'application/json', 'User-Agent' => USER_AGENT }.freeze
 
-      attr_accessor :host, :headers
+      attr_accessor :host, :headers, :cache, :logger
 
       def initialize
         @host = host || LAA_FEE_CALCULATOR_API_V1

--- a/lib/laa/fee_calculator/connection.rb
+++ b/lib/laa/fee_calculator/connection.rb
@@ -2,6 +2,7 @@
 
 require 'singleton'
 require 'faraday'
+require 'faraday/http_cache'
 
 module LAA
   module FeeCalculator
@@ -16,6 +17,7 @@ module LAA
       def initialize
         @conn = Faraday.new(url: LAA::FeeCalculator.configuration.host, headers: default_headers) do |conn|
           conn.use LAA::FeeCalculator::RaiseError
+          conn.use(:http_cache, store: cache, logger: logger) if cache
           conn.adapter :net_http
         end
       end
@@ -38,6 +40,14 @@ module LAA
 
       def default_headers
         LAA::FeeCalculator.configuration.headers
+      end
+
+      def cache
+        LAA::FeeCalculator.configuration.cache
+      end
+
+      def logger
+        LAA::FeeCalculator.configuration.logger
       end
     end
   end

--- a/lib/laa/fee_calculator/version.rb
+++ b/lib/laa/fee_calculator/version.rb
@@ -2,7 +2,7 @@
 
 module LAA
   module FeeCalculator
-    VERSION = '1.3.1'
+    VERSION = '1.4.0'
     USER_AGENT = "laa-fee-calculator-client/#{VERSION}"
   end
 end


### PR DESCRIPTION
#### What

Add options for caching

#### Ticket

N/A

#### Why

Data from Fee Calculator is static so requests can be cached. Caching is enabled in the server by https://github.com/ministryofjustice/laa-fee-calculator/pull/235

#### How

Use `faraday-http-cache` and add configuration options so that a cache store and logger can be provided.
