### PR TITLE
Update ruby version test script to newer versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Bug reports and pull requests are welcome on GitHub at [ministryofjustice/laa-fe
 
 1. Make required changes, run specs (rerecord vcr cassettes if necessary)
 
-2. Run `bin/ruby_version_test` to test against ruby versions (2.7+ supported at present)
+2. Run `bin/ruby_version_test` to test against ruby versions (3.0+ supported at present)
 
 3. Update the VERSION in `lib/laa/fee_calculator/version` using [semantic versioning](https://guides.rubygems.org/patterns/#semantic-versioning).
 

--- a/bin/ruby_version_test
+++ b/bin/ruby_version_test
@@ -2,7 +2,7 @@
 
 set -e
 
-RUBIES="2.7 3.0 3.1"
+RUBIES="3.0 3.1 3.2 3.3"
 
 if [ -e Gemfile.lock ]
 then


### PR DESCRIPTION
#### What

Update `bin/ruby_version_test` to use newer Ruby versions.

#### Ticket

[Maintenance of Fee Calculator Client gem](https://dsdmoj.atlassian.net/browse/CTSKF-634)

#### Why

Supported Ruby versions have been updated.

#### How

Change the `RUBIES` constants.